### PR TITLE
Fix unquoted os strings

### DIFF
--- a/manifests/autostartdatabase.pp
+++ b/manifests/autostartdatabase.pp
@@ -10,7 +10,7 @@ define oradb::autostartdatabase( $oracleHome  = undef,
   include oradb::prepareautostart
 
   case $::kernel {
-    Linux: {
+    'Linux': {
       $execPath    = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:'
     }
     default: {

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -96,7 +96,7 @@ define oradb::database( $oracleBase               = undef,
 
   if ( $continue ) {
     case $::kernel {
-      Linux,SunOS: {
+      'Linux', 'SunOS': {
         $execPath    = "${oracleHome}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:"
         $path        = $downloadDir
 

--- a/manifests/dbactions.pp
+++ b/manifests/dbactions.pp
@@ -23,7 +23,7 @@ define oradb::dbactions( $oracleHome  = undef,
 
 {
   case $::kernel {
-    Linux, SunOS: {
+    'Linux', 'SunOS': {
       $execPath    = "${oracleHome}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:"
       Exec { path  => $execPath,
         user       => $user,

--- a/manifests/opatchupgrade.pp
+++ b/manifests/opatchupgrade.pp
@@ -64,7 +64,7 @@ define oradb::opatchupgrade( $oracleHome              = undef,
     }
 
     case $::kernel {
-      Linux, SunOS: {
+      'Linux', 'SunOS': {
         file { "remove_old":
           ensure     => absent,
           recurse    => true,

--- a/manifests/prepareautostart.pp
+++ b/manifests/prepareautostart.pp
@@ -6,7 +6,7 @@
 class oradb::prepareautostart
 {
   case $::kernel {
-    Linux: {
+    'Linux': {
       $execPath    = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:'
     }
     default: {


### PR DESCRIPTION
On the newer versions of Puppet unquoted os strings fail
