### PR TITLE
Add possibility to create an oracle database from template

### DIFF
--- a/templates/dbtemplate.dbt.erb
+++ b/templates/dbtemplate.dbt.erb
@@ -1,0 +1,239 @@
+<DatabaseTemplate name="<%= @dbName %>" description="<%= @dbName %> template" version="12.1.0.0.0">
+   <CommonAttributes>
+      <option name="OMS" value="false"/>
+      <option name="JSERVER" value="true"/>
+      <option name="SPATIAL" value="false"/>
+      <option name="IMEDIA" value="false"/>
+      <option name="XDB_PROTOCOLS" value="true">
+         <tablespace id="SYSAUX"/>
+      </option>
+      <option name="ORACLE_TEXT" value="false">
+         <tablespace id="SYSAUX"/>
+      </option>
+      <option name="SAMPLE_SCHEMA" value="false"/>
+      <option name="CWMLITE" value="false">
+         <tablespace id="SYSAUX"/>
+      </option>
+      <option name="APEX" value="false">
+         <tablespace id="SYSAUX"/>
+      </option>
+      <option name="DV" value="false">
+         <tablespace id="SYSAUX"/>
+      </option>
+   </CommonAttributes>
+   <Variables/>
+   <CustomScripts Execute="false"/>
+   <InitParamAttributes>
+      <InitParams>
+         <initParam name="db_name" value="<%= @dbName %>"/>
+         <initParam name="db_domain" value="<%= @dbDomain %>"/>
+         <initParam name="dispatchers" value="(PROTOCOL=TCP) (SERVICE={SID}XDB)"/>
+         <initParam name="audit_file_dest" value="{ORACLE_BASE}/admin/{DB_UNIQUE_NAME}/adump"/>
+         <initParam name="compatible" value="12.1.0.0.0"/>
+         <initParam name="remote_login_passwordfile" value="EXCLUSIVE"/>
+         <initParam name="memory_target" value="<%= @memoryTotal %>" unit="MB"/>
+         <initParam name="processes" value="1000"/>
+         <initParam name="undo_tablespace" value="UNDOTBS1"/>
+         <initParam name="control_files" value="(&quot;<%= @oracleBase %>/oradata/{DB_UNIQUE_NAME}/control01.ctl&quot;, &quot;<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/control02.ctl&quot;)"/>
+         <initParam name="diagnostic_dest" value="{ORACLE_BASE}"/>
+         <initParam name="db_recovery_file_dest" value="<%= @recoveryAreaDestination %>"/>
+         <initParam name="audit_trail" value="none"/>
+         <initParam name="db_block_size" value="8" unit="KB"/>
+         <initParam name="open_cursors" value="300"/>
+         <initParam name="db_recovery_file_dest_size" value="1" unit="GB"/>
+      </InitParams>
+      <MiscParams>
+         <databaseType>MULTIPURPOSE</databaseType>
+         <maxUserConn>20</maxUserConn>
+         <customSGA>false</customSGA>
+         <characterSet>"<%= @characterSet %>"</characterSet>
+         <nationalCharacterSet>"<%= @nationalCharacterSet %>"</nationalCharacterSet>
+         <archiveLogMode>false</archiveLogMode>
+         <initParamFileName>{ORACLE_BASE}/admin/{DB_UNIQUE_NAME}/pfile/init.ora</initParamFileName>
+      </MiscParams>
+      <SPfile useSPFile="true">{ORACLE_HOME}/dbs/spfile{SID}.ora</SPfile>
+   </InitParamAttributes>
+   <StorageAttributes>
+      <ControlfileAttributes id="Controlfile">
+         <maxDatafiles>100</maxDatafiles>
+         <maxLogfiles>16</maxLogfiles>
+         <maxLogMembers>3</maxLogMembers>
+         <maxLogHistory>1</maxLogHistory>
+         <maxInstances>8</maxInstances>
+         <image name="control01.ctl" filepath="<%= @oracleBase %>/oradata/{DB_UNIQUE_NAME}/"/>
+         <image name="control02.ctl" filepath="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/"/>
+      </ControlfileAttributes>
+      <DatafileAttributes id="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/sysaux01.dbf" con_id="1">
+         <tablespace>SYSAUX</tablespace>
+         <temporary>false</temporary>
+         <online>true</online>
+         <status>0</status>
+         <size unit="MB">550</size>
+         <reuse>true</reuse>
+         <autoExtend>true</autoExtend>
+         <increment unit="KB">10240</increment>
+         <maxSize unit="MB">4096</maxSize>
+      </DatafileAttributes>
+      <DatafileAttributes id="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/system01.dbf" con_id="1">
+         <tablespace>SYSTEM</tablespace>
+         <temporary>false</temporary>
+         <online>true</online>
+         <status>0</status>
+         <size unit="MB">700</size>
+         <reuse>true</reuse>
+         <autoExtend>true</autoExtend>
+         <increment unit="KB">10240</increment>
+         <maxSize unit="MB">4096</maxSize>
+      </DatafileAttributes>
+      <DatafileAttributes id="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/temp01.dbf" con_id="1">
+         <tablespace>TEMP</tablespace>
+         <temporary>false</temporary>
+         <online>true</online>
+         <status>0</status>
+         <size unit="MB">2048</size>
+         <reuse>true</reuse>
+         <autoExtend>true</autoExtend>
+         <increment unit="KB">640</increment>
+         <maxSize unit="MB">4096</maxSize>
+      </DatafileAttributes>
+      <DatafileAttributes id="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/undotbs01.dbf" con_id="1">
+         <tablespace>UNDOTBS1</tablespace>
+         <temporary>false</temporary>
+         <online>true</online>
+         <status>0</status>
+         <size unit="MB">2048</size>
+         <reuse>true</reuse>
+         <autoExtend>true</autoExtend>
+         <increment unit="KB">5120</increment>
+         <maxSize unit="MB">4096</maxSize>
+      </DatafileAttributes>
+      <TablespaceAttributes id="SYSAUX" con_id="1">
+         <temporary>false</temporary>
+         <defaultTemp>false</defaultTemp>
+         <undo>false</undo>
+         <local>true</local>
+         <blockSize>-1</blockSize>
+         <allocation>1</allocation>
+         <uniAllocSize unit="KB">-1</uniAllocSize>
+         <initSize unit="KB">64</initSize>
+         <increment unit="KB">64</increment>
+         <incrementPercent>50</incrementPercent>
+         <minExtends>1</minExtends>
+         <maxExtends>4096</maxExtends>
+         <minExtendsSize unit="KB">64</minExtendsSize>
+         <logging>true</logging>
+         <recoverable>false</recoverable>
+         <maxFreeSpace>0</maxFreeSpace>
+         <autoSegmentMgmt>true</autoSegmentMgmt>
+         <bigfile>false</bigfile>
+         <datafilesList>
+            <TablespaceDatafileAttributes id="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/sysaux01.dbf">
+               <id>-1</id>
+            </TablespaceDatafileAttributes>
+         </datafilesList>
+      </TablespaceAttributes>
+      <TablespaceAttributes id="SYSTEM" con_id="1">
+         <temporary>false</temporary>
+         <defaultTemp>false</defaultTemp>
+         <undo>false</undo>
+         <local>true</local>
+         <blockSize>-1</blockSize>
+         <allocation>3</allocation>
+         <uniAllocSize unit="KB">-1</uniAllocSize>
+         <initSize unit="KB">64</initSize>
+         <increment unit="KB">64</increment>
+         <incrementPercent>50</incrementPercent>
+         <minExtends>1</minExtends>
+         <maxExtends>-1</maxExtends>
+         <minExtendsSize unit="KB">64</minExtendsSize>
+         <logging>true</logging>
+         <recoverable>false</recoverable>
+         <maxFreeSpace>0</maxFreeSpace>
+         <autoSegmentMgmt>true</autoSegmentMgmt>
+         <bigfile>false</bigfile>
+         <datafilesList>
+            <TablespaceDatafileAttributes id="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/system01.dbf">
+               <id>-1</id>
+            </TablespaceDatafileAttributes>
+         </datafilesList>
+      </TablespaceAttributes>
+      <TablespaceAttributes id="TEMP" con_id="1">
+         <temporary>true</temporary>
+         <defaultTemp>true</defaultTemp>
+         <undo>false</undo>
+         <local>true</local>
+         <blockSize>-1</blockSize>
+         <allocation>1</allocation>
+         <uniAllocSize unit="KB">-1</uniAllocSize>
+         <initSize unit="KB">64</initSize>
+         <increment unit="KB">64</increment>
+         <incrementPercent>0</incrementPercent>
+         <minExtends>1</minExtends>
+         <maxExtends>0</maxExtends>
+         <minExtendsSize unit="KB">64</minExtendsSize>
+         <logging>true</logging>
+         <recoverable>false</recoverable>
+         <maxFreeSpace>0</maxFreeSpace>
+         <autoSegmentMgmt>true</autoSegmentMgmt>
+         <bigfile>false</bigfile>
+         <datafilesList>
+            <TablespaceDatafileAttributes id="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/temp01.dbf">
+               <id>-1</id>
+            </TablespaceDatafileAttributes>
+         </datafilesList>
+      </TablespaceAttributes>
+      <TablespaceAttributes id="UNDOTBS1" con_id="1">
+         <temporary>false</temporary>
+         <defaultTemp>false</defaultTemp>
+         <undo>true</undo>
+         <local>true</local>
+         <blockSize>-1</blockSize>
+         <allocation>1</allocation>
+         <uniAllocSize unit="KB">-1</uniAllocSize>
+         <initSize unit="KB">512</initSize>
+         <increment unit="KB">512</increment>
+         <incrementPercent>50</incrementPercent>
+         <minExtends>8</minExtends>
+         <maxExtends>4096</maxExtends>
+         <minExtendsSize unit="KB">512</minExtendsSize>
+         <logging>true</logging>
+         <recoverable>false</recoverable>
+         <maxFreeSpace>0</maxFreeSpace>
+         <autoSegmentMgmt>true</autoSegmentMgmt>
+         <bigfile>false</bigfile>
+         <datafilesList>
+            <TablespaceDatafileAttributes id="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/undotbs01.dbf">
+               <id>-1</id>
+            </TablespaceDatafileAttributes>
+         </datafilesList>
+      </TablespaceAttributes>
+      <RedoLogGroupAttributes id="1">
+         <reuse>false</reuse>
+         <fileSize unit="KB">512000</fileSize>
+         <Thread>1</Thread>
+         <member ordinal="0" memberName="redo0101.log" filepath="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/"/>
+         <member ordinal="0" memberName="redo0102.log" filepath="<%= @oracleBase %>/oradata/{DB_UNIQUE_NAME}/"/>
+      </RedoLogGroupAttributes>
+      <RedoLogGroupAttributes id="2">
+         <reuse>false</reuse>
+         <fileSize unit="KB">512000</fileSize>
+         <Thread>1</Thread>
+         <member ordinal="0" memberName="redo0201.log" filepath="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/"/>
+         <member ordinal="0" memberName="redo0202.log" filepath="<%= @oracleBase %>/oradata/{DB_UNIQUE_NAME}/"/>
+      </RedoLogGroupAttributes>
+      <RedoLogGroupAttributes id="3">
+         <reuse>false</reuse>
+         <fileSize unit="KB">512000</fileSize>
+         <Thread>1</Thread>
+         <member ordinal="0" memberName="redo0301.log" filepath="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/"/>
+         <member ordinal="0" memberName="redo0302.log" filepath="<%= @oracleBase %>/oradata/{DB_UNIQUE_NAME}/"/>
+      </RedoLogGroupAttributes>
+      <RedoLogGroupAttributes id="4">
+         <reuse>false</reuse>
+         <fileSize unit="KB">512000</fileSize>
+         <Thread>1</Thread>
+         <member ordinal="0" memberName="redo0401.log" filepath="<%= @dataFileDestination %>/{DB_UNIQUE_NAME}/"/>
+         <member ordinal="0" memberName="redo0402.log" filepath="<%= @oracleBase %>/oradata/{DB_UNIQUE_NAME}/"/>
+      </RedoLogGroupAttributes>
+   </StorageAttributes>
+</DatabaseTemplate>


### PR DESCRIPTION
By default the module works like before. If you specify a template the command changes. I have added one example dbtemplate into the module but people can create there own.
