### PR TITLE
Order the Hash items in init params to get consistency

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -79,7 +79,8 @@ define oradb::database(
 
     if (is_hash($initParams) or is_string($initParams)) {
       if is_hash($initParams) {
-        $sanitizedInitParams = join(join_keys_to_values($initParams, '='),',')
+        $initParamsArray = sort(join_keys_to_values($initParams, '='))
+        $sanitizedInitParams = join($initParamsArray,',')
       } else {
         $sanitizedInitParams = $initParams
       }


### PR DESCRIPTION
Should fix problem introduced by #37. You have to test this though. I'm guessing the problem is caused by unordered Hashes on a ruby 1.8.7 system.
