### PR TITLE
fix bug for prepareautostart failed due to chkconfig(version 1.3.30.2) in Oracle Linux Server release 5.7

### DIFF
--- a/manifests/prepareautostart.pp
+++ b/manifests/prepareautostart.pp
@@ -31,7 +31,7 @@ class oradb::prepareautostart
         command   => 'chkconfig --add dbora',
         require   => File['/etc/init.d/dbora'],
         user      => 'root',
-        unless    => 'chkconfig | /bin/grep \'dbora\'',
+        unless    => 'chkconfig --list | /bin/grep \'dbora\'',
         path      => $execPath,
         logoutput => true,
       }


### PR DESCRIPTION
prepareautostart failed due to chkconfig(version 1.3.30.2) in Oracle Linux Server release 5.7

It's due to the code in prepareautostart.pp

unless         => "chkconfig | /bin/grep 'dbora'",
with testing

[xxx@domain ~]$ cat /etc/issue | grep Linux
Oracle Linux Server release 5.7

[xxx@domain ~]$ chkconfig  | /bin/grep 'dbora'
chkconfig version 1.3.30.2 - Copyright (C) 1997-2000 Red Hat, Inc.
This may be freely redistributed under the terms of the GNU Public
License.

usage:   chkconfig --list [name]
chkconfig --add <name>
chkconfig --del <name>
chkconfig [--level <levels>] <name>
<on|off|reset|resetpriorities>

[xxx@domain ~]$ chkconfig  --list | /bin/grep 'dbora'
dbora           0:off   1:off   2:off   3:on    4:on    5:on    6:off
,so change the unless check code , then okay, both works in Oracle
Linux 5 & 6

unless         => "chkconfig --list | /bin/grep 'dbora'",