### PR TITLE
Fix unsetted vars in dbora template

### DIFF
--- a/manifests/autostartdatabase.pp
+++ b/manifests/autostartdatabase.pp
@@ -7,7 +7,11 @@ define oradb::autostartdatabase(
   $dbName      = undef,
   $user        = 'oracle',
 ){
-  include oradb::prepareautostart
+
+  class { 'oradb::prepareautostart':
+    oracleHome => $oracleHome,
+    user       => $user,
+  }
 
   $execPath    = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:'
 

--- a/manifests/prepareautostart.pp
+++ b/manifests/prepareautostart.pp
@@ -2,8 +2,10 @@
 #
 #  prepare autostart of the nodemanager for linux
 #
-class oradb::prepareautostart
-{
+class oradb::prepareautostart(
+  $oracleHome  = undef,
+  $user        = 'oracle'
+){
   $execPath = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:'
 
   case $::kernel {


### PR DESCRIPTION
In dbora template, the following vars are unsetted:

ORA_HOME=<%= @oracleHome %>
ORA_OWNER=<%= @user %>

We must pass these variables in input of class oradb::prepareautostart.

