### PR TITLE
Added ability to put listener entries in tnsnames.ora. Fixes #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Should work for Puppet 2.7 & 3.0
 - Oracle Database Net configuration
 - Oracle Database Listener
 - Tnsnames entry
+- Listener entry in tnsnames.ora
 - Oracle ASM
 - Oracle RAC
 - OPatch upgrade
@@ -648,6 +649,15 @@ Tnsnames.ora
       server             => { myserver => { host => soadb.example.nl, port => '1525', protocol => 'TCP' }, { host => soadb2.example.nl, port => '1526', protocol => 'TCP' }},
       connectServiceName => 'soarepos.example.nl',
       connectServer      => 'DEDICATED',
+      require            => Oradb::Dbactions['start oraDb'],
+    }
+
+    oradb::tnsnames{'testlistener':
+      entry_type         => 'listener'
+      oracleHome         => '/oracle/product/11.2/db',
+      user               => 'oracle',
+      group              => 'dba',
+      server             => { myserver => { host => soadb.example.nl, port => '1521', protocol => 'TCP' }},
       require            => Oradb::Dbactions['start oraDb'],
     }
 

--- a/manifests/tnsnames.pp
+++ b/manifests/tnsnames.pp
@@ -10,6 +10,7 @@ define oradb::tnsnames(
   $failover           = 'ON',
   $connectServiceName = undef,
   $connectServer      = 'DEDICATED',
+  $entry_type         = 'tnsname',
 )
 {
   if ! defined(Concat["${oracleHome}/network/admin/tnsnames.ora"]) {
@@ -22,8 +23,14 @@ define oradb::tnsnames(
     }
   }
 
+  case $entry_type {
+    'tnsname'  : { $template_path = 'oradb/tnsnames.erb' }
+    'listener' : { $template_path = 'oradb/listener.erb' }
+    default    : { fail("${entry_type} is not a supported entry_type") }
+  }
+
   concat::fragment { $title:
     target  => "${oracleHome}/network/admin/tnsnames.ora",
-    content => template('oradb/tnsnames.erb'),
+    content => template($template_path),
   }
 }

--- a/templates/listener.erb
+++ b/templates/listener.erb
@@ -1,0 +1,13 @@
+
+<%= @title %> =
+  <%- if @server.length == 1 -%>
+  <%- @server.each_pair do |key, server| -%>
+  (ADDRESS = (PROTOCOL = <%= server['protocol'] %>)(HOST = <%= server['host'] %>)(PORT = <%= server['port'] %>))
+  <%- end -%>
+  <%- else -%>
+  (ADDRESS_LIST=
+   <%- @server.each_pair do |key, server| -%>
+    (ADDRESS = (PROTOCOL = <%= server['protocol'] %>)(HOST = <%= server['host'] %>)(PORT = <%= server['port'] %>))
+     <%- end -%>
+    )
+  <%- end -%>


### PR DESCRIPTION
This fixes #62 by adding the ability to use an alternate template for an entry. The new template is just a slightly adjusted version of tnsnames.erb