### PR TITLE
Fix LD_LIBRARY_PATH having no effect

### DIFF
--- a/lib/puppet/provider/db_rcu/db_rcu.rb
+++ b/lib/puppet/provider/db_rcu/db_rcu.rb
@@ -53,7 +53,7 @@ EOS
     FileUtils.chmod(0555, tmpFile.path)
 
     Puppet.debug "rcu for prefix #{prefix} execute SQL"
-    output = `su - #{user} -c 'export ORACLE_HOME=#{oracle_home};LD_LIBRARY_PATH=#{oracle_home}/lib;#{oracle_home}/bin/sqlplus \"#{sys_user}/#{sys_password}@//#{db_server}/#{db_service} as sysdba\" @#{tmpFile.path}'`
+    output = `su - #{user} -c 'export ORACLE_HOME=#{oracle_home};LD_LIBRARY_PATH=#{oracle_home}/lib #{oracle_home}/bin/sqlplus \"#{sys_user}/#{sys_password}@//#{db_server}/#{db_service} as sysdba\" @#{tmpFile.path}'`
     raise ArgumentError, "Error executing puppet code, #{output}" if $? != 0
 
     if FileTest.exists?("/tmp/check_rcu_#{prefix}2.txt")


### PR DESCRIPTION
Remove the semi-colon, so that LD_LIBRARY_PATH is correct when sqlplus
is run.

This fixes errors like:
'/usr/lib/oracle/11.2/client64/bin/sqlplus: error while loading shared
libraries: libsqlplus.so: cannot open shared object file: No such file
or directory'.  In this case, oracle_home was set to the installation
location of an oracle instant client RPM.