### PR TITLE
RFC: Better defaults for ora inventory location

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --format documentation

--- a/lib/facter/oracle_database_homes.rb
+++ b/lib/facter/oracle_database_homes.rb
@@ -56,7 +56,7 @@ def get_orainst_loc
     end
     return str
   else
-    return 'NotFound'
+    return nil
   end
 end
 

--- a/lib/puppet/parser/functions/oradb_cleanpath.rb
+++ b/lib/puppet/parser/functions/oradb_cleanpath.rb
@@ -1,0 +1,9 @@
+require 'pathname'
+module Puppet::Parser::Functions
+  newfunction(:oradb_cleanpath, :type => :rvalue) do |args|
+    raise Puppet::ParseError, "oradb_cleanpath requires exactly 1 argument" unless args.count == 1
+    raise Puppet::ParseError, "oradb_cleanpath requires a string argument"  unless args[0].is_a? String
+    path = Pathname.new(args[0])
+    path.cleanpath.to_s
+  end
+end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -6,6 +6,7 @@ define oradb::client(
   $file                      = undef,
   $oracle_base               = undef,
   $oracle_home               = undef,
+  $ora_inventory_dir         = undef,
   $db_port                   = '1521',
   $user                      = 'oracle',
   $user_base_dir             = '/home',
@@ -18,6 +19,9 @@ define oradb::client(
   $logoutput                 = true,
 )
 {
+  validate_absolute_path($oracle_home)
+  validate_absolute_path($oracle_base)
+
   # check if the oracle software already exists
   $found = oracle_exists( $oracle_home )
 
@@ -32,7 +36,12 @@ define oradb::client(
     }
   }
 
-  $oraInventory = "${oracle_base}/oraInventory"
+  if $ora_inventory_dir == undef {
+    $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base}/../oraInventory")
+  } else {
+    validate_absolute_path($ora_inventory_dir)
+    $oraInventory = "${ora_inventory_dir}/oraInventory"
+  }
 
   db_directory_structure{"client structure ${version}":
     ensure            => present,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -37,7 +37,7 @@ define oradb::client(
   }
 
   if $ora_inventory_dir == undef {
-    $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base}/../oraInventory")
+    $oraInventory = pick($::oradb_inst_loc_data,oradb_cleanpath("${oracle_base}/../oraInventory"))
   } else {
     validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"

--- a/manifests/goldengate.pp
+++ b/manifests/goldengate.pp
@@ -9,6 +9,7 @@ define oradb::goldengate(
   $database_version          = 'ORA11g',  # 'ORA11g'|'ORA12c'  only for > 12.1.2
   $database_home             = undef,     # only for > 12.1.2
   $oracle_base               = undef,     # only for > 12.1.2
+  $ora_inventory_dir         = undef,
   $goldengate_home           = undef,
   $manager_port              = undef,
   $user                      = 'ggate',
@@ -54,7 +55,12 @@ define oradb::goldengate(
 
 
   if ( $version == '12.1.2' ) {
-    $oraInventory    = "${oracle_base}/oraInventory"
+    if $ora_inventory_dir == undef {
+      $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base}/../oraInventory")
+    } else {
+      validate_absolute_path($ora_inventory_dir)
+      $oraInventory = "${ora_inventory_dir}/oraInventory"
+    }
 
     db_directory_structure{"oracle goldengate structure ${version}":
       ensure            => present,

--- a/manifests/goldengate.pp
+++ b/manifests/goldengate.pp
@@ -56,7 +56,7 @@ define oradb::goldengate(
 
   if ( $version == '12.1.2' ) {
     if $ora_inventory_dir == undef {
-      $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base}/../oraInventory")
+      $oraInventory = pick($::oradb_inst_loc_data,oradb_cleanpath("${oracle_base}/../oraInventory"))
     } else {
       validate_absolute_path($ora_inventory_dir)
       $oraInventory = "${ora_inventory_dir}/oraInventory"

--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -76,8 +76,9 @@ define oradb::installasm(
   }
 
   if $ora_inventory_dir == undef {
-    $oraInventory = "${grid_base}/oraInventory"
+    $oraInventory = pick($::oradb_inst_loc_data,"${grid_base}/../oraInventory")
   } else {
+    validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"
   }
 

--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -76,7 +76,7 @@ define oradb::installasm(
   }
 
   if $ora_inventory_dir == undef {
-    $oraInventory = pick($::oradb_inst_loc_data,"${grid_base}/../oraInventory")
+    $oraInventory = pick($::oradb_inst_loc_data,oradb_cleanpath("${grid_base}/../oraInventory"))
   } else {
     validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"

--- a/manifests/installdb.pp
+++ b/manifests/installdb.pp
@@ -80,7 +80,7 @@ define oradb::installdb(
   }
 
   if $ora_inventory_dir == undef {
-    $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base}/../oraInventory")
+    $oraInventory = pick($::oradb_inst_loc_data,oradb_cleanpath("${oracle_base}/../oraInventory"))
   } else {
     validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"

--- a/manifests/installdb.pp
+++ b/manifests/installdb.pp
@@ -27,7 +27,7 @@ define oradb::installdb(
   $puppet_download_mnt_point = undef,
   $remote_file               = true,
   $cluster_nodes             = undef,
-  $cleanup_install_files      = true,
+  $cleanup_install_files     = true,
 )
 {
   if ( $create_user == true ){
@@ -80,8 +80,9 @@ define oradb::installdb(
   }
 
   if $ora_inventory_dir == undef {
-    $oraInventory = "${oracle_base}/oraInventory"
+    $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base}/../oraInventory")
   } else {
+    validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"
   }
 

--- a/manifests/installem.pp
+++ b/manifests/installem.pp
@@ -51,8 +51,9 @@ define oradb::installem(
   }
 
   if $ora_inventory_dir == undef {
-    $oraInventory = "${oracle_base_dir}/oraInventory"
+    $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base_dir}/../oraInventory")
   } else {
+    validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"
   }
 

--- a/manifests/installem.pp
+++ b/manifests/installem.pp
@@ -51,7 +51,7 @@ define oradb::installem(
   }
 
   if $ora_inventory_dir == undef {
-    $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base_dir}/../oraInventory")
+    $oraInventory = pick($::oradb_inst_loc_data,oradb_cleanpath("${oracle_base_dir}/../oraInventory"))
   } else {
     validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"

--- a/manifests/installem_agent.pp
+++ b/manifests/installem_agent.pp
@@ -30,6 +30,7 @@ define oradb::installem_agent(
   }
 
   # check if the oracle software already exists
+  validate_absolute_path( $agent_base_dir )
   $found = oracle_exists( $agent_base_dir )
 
   if $found == undef {
@@ -43,9 +44,11 @@ define oradb::installem_agent(
     }
   }
 
+  validate_absolute_path($oracle_base_dir)
   if $ora_inventory_dir == undef {
-    $oraInventory = "${oracle_base_dir}/oraInventory"
+    $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base_dir}/../oraInventory")
   } else {
+    validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"
   }
 

--- a/manifests/installem_agent.pp
+++ b/manifests/installem_agent.pp
@@ -46,7 +46,7 @@ define oradb::installem_agent(
 
   validate_absolute_path($oracle_base_dir)
   if $ora_inventory_dir == undef {
-    $oraInventory = pick($::oradb_inst_loc_data,"${oracle_base_dir}/../oraInventory")
+    $oraInventory = pick($::oradb_inst_loc_data,oradb_cleanpath("${oracle_base_dir}/../oraInventory"))
   } else {
     validate_absolute_path($ora_inventory_dir)
     $oraInventory = "${ora_inventory_dir}/oraInventory"

--- a/manifests/utils/dborainst.pp
+++ b/manifests/utils/dborainst.pp
@@ -25,7 +25,7 @@ define oradb::utils::dborainst
       }
     }
     default: {
-        fail("Unrecognized operating system ${::kernel}, please use it on a Linux host")
+        fail("Unrecognized operating system ${::kernel}, please use it on a Linux or SunOS host")
     }
   }
 

--- a/spec/defines/installdb_remote_spec.rb
+++ b/spec/defines/installdb_remote_spec.rb
@@ -7,8 +7,8 @@ describe 'oradb::installdb', :type => :define do
           :version                   => '12.1.0.1',
           :file                      => 'linuxamd64_12c_database',
           :database_type             => 'SE',
-          :oracle_base               => '/oracle',
-          :oracle_home               => '/oracle/product/12.1/db',
+          :oracle_base               => '/u01/app/oracle',
+          :oracle_home               => '/u01/app/oracle/product/12.1/db',
           :user                      => 'oracle',
           :group                     => 'dba',
           :group_install             => 'oinstall',
@@ -28,8 +28,8 @@ describe 'oradb::installdb', :type => :define do
         it do
           should contain_db_directory_structure("oracle structure 12.1.0.1").with({
               'ensure'            => 'present',
-              'oracle_base_dir'   => '/oracle',
-              'ora_inventory_dir' => '/oracle/../oraInventory',
+              'oracle_base_dir'   => '/u01/app/oracle',
+              'ora_inventory_dir' => '/u01/app/oraInventory',
               'os_user'           => 'oracle',
               'os_group'          => 'oinstall',
               'download_dir'      => '/install',
@@ -40,7 +40,7 @@ describe 'oradb::installdb', :type => :define do
       describe "oradb orainst" do
         it do
           should contain_oradb__utils__dborainst('database orainst 12.1.0.1').with({
-             'ora_inventory_dir' => '/oracle/../oraInventory',
+             'ora_inventory_dir' => '/u01/app/oraInventory',
              'os_group'          => 'oinstall',
            })
         end
@@ -119,7 +119,7 @@ describe 'oradb::installdb', :type => :define do
       it {
            should contain_exec("install oracle database 12.1.0.1_Linux-x86-64").with({
              'command'  => "/bin/sh -c 'unset DISPLAY;/install/linuxamd64_12c_database/database/runInstaller -silent -waitforcompletion -ignoreSysPrereqs -ignorePrereq -responseFile /install/db_install_12.1.0.1.rsp'",
-             'creates'  => "/oracle/product/12.1/db/dbs",
+             'creates'  => "/u01/app/oracle/product/12.1/db/dbs",
              'group'    => 'oinstall',
            }).that_requires('Oradb::Utils::Dborainst[database orainst 12.1.0.1]').that_requires('File[/install/db_install_12.1.0.1.rsp]')
          }
@@ -127,7 +127,7 @@ describe 'oradb::installdb', :type => :define do
 
     describe "oracle home" do
       it do
-        should contain_file("/oracle/product/12.1/db").with({
+        should contain_file("/u01/app/oracle/product/12.1/db").with({
              'ensure'  => 'directory',
              'owner'   => 'oracle',
              'group'   => 'oinstall',
@@ -147,7 +147,7 @@ describe 'oradb::installdb', :type => :define do
     describe "exec root.sh" do
       it do
         should contain_exec("run root.sh script 12.1.0.1_Linux-x86-64").with({
-             'command' => '/oracle/product/12.1/db/root.sh',
+             'command' => '/u01/app/oracle/product/12.1/db/root.sh',
              'group'   => 'root',
            }).that_requires('Exec[install oracle database 12.1.0.1_Linux-x86-64]')
       end
@@ -157,19 +157,19 @@ describe 'oradb::installdb', :type => :define do
 
   describe "CentOS local" do
     let(:params){{
-          :version                 => '11.2.0.4',
-          :file                    => 'p13390677_112040_Linux-x86-64',
-          :database_type            => 'SE',
-          :oracle_base              => '/oracle',
-          :oracle_home              => '/oracle/product/11.2/db',
-          :user                    => 'oracle',
-          :group                   => 'dba',
-          :group_install           => 'oinstall',
-          :group_oper              => 'oper',
-          :remote_file              => false,
-          :zip_extract              => true,
-          :download_dir             => '/install',
-          :puppet_download_mnt_point  => '/software',
+          :version                   => '11.2.0.4',
+          :file                      => 'p13390677_112040_Linux-x86-64',
+          :database_type             => 'SE',
+          :oracle_base               => '/u01/app/oracle',
+          :oracle_home               => '/u01/app/oracle/product/11.2/db',
+          :user                      => 'oracle',
+          :group                     => 'dba',
+          :group_install             => 'oinstall',
+          :group_oper                => 'oper',
+          :remote_file               => false,
+          :zip_extract               => true,
+          :download_dir              => '/install',
+          :puppet_download_mnt_point => '/software',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
     let(:facts) {{ :operatingsystem => 'CentOS' ,
@@ -179,12 +179,12 @@ describe 'oradb::installdb', :type => :define do
     describe "oradb utils structure" do
       it do
         should contain_db_directory_structure("oracle structure 11.2.0.4").with({
-              'ensure'                => 'present',
-              'oracle_base_dir'       => '/oracle',
-              'ora_inventory_dir'     => '/oracle/../oraInventory',
-              'os_user'               => 'oracle',
-              'os_group'              => 'oinstall',
-              'download_dir'          => '/install',
+              'ensure'            => 'present',
+              'oracle_base_dir'   => '/u01/app/oracle',
+              'ora_inventory_dir' => '/u01/app/oraInventory',
+              'os_user'           => 'oracle',
+              'os_group'          => 'oinstall',
+              'download_dir'      => '/install',
            })
       end
     end
@@ -192,8 +192,8 @@ describe 'oradb::installdb', :type => :define do
     describe "oradb orainst" do
       it do
         should contain_oradb__utils__dborainst('database orainst 11.2.0.4').with({
-             'ora_inventory_dir'  => '/oracle/../oraInventory',
-             'os_group'           => 'oinstall',
+             'ora_inventory_dir' => '/u01/app/oraInventory',
+             'os_group'          => 'oinstall',
            })
       end
     end
@@ -224,7 +224,7 @@ describe 'oradb::installdb', :type => :define do
       it {
            should contain_exec("install oracle database 11.2.0.4_Linux-x86-64").with({
              'command'  => "/bin/sh -c 'unset DISPLAY;/install/p13390677_112040_Linux-x86-64/database/runInstaller -silent -waitforcompletion -ignoreSysPrereqs -ignorePrereq -responseFile /install/db_install_11.2.0.4.rsp'",
-             'creates'  => "/oracle/product/11.2/db/dbs",
+             'creates'  => "/u01/app/oracle/product/11.2/db/dbs",
              'group'    => 'oinstall',
            }).that_requires('Oradb::Utils::Dborainst[database orainst 11.2.0.4]').that_requires('File[/install/db_install_11.2.0.4.rsp]')
          }
@@ -232,7 +232,7 @@ describe 'oradb::installdb', :type => :define do
 
     describe "oracle home" do
       it do
-        should contain_file("/oracle/product/11.2/db").with({
+        should contain_file("/u01/app/oracle/product/11.2/db").with({
              'ensure'  => 'directory',
              'owner'   => 'oracle',
              'group'   => 'oinstall',
@@ -252,7 +252,7 @@ describe 'oradb::installdb', :type => :define do
     describe "exec root.sh" do
       it do
         should contain_exec("run root.sh script 11.2.0.4_Linux-x86-64").with({
-             'command' => '/oracle/product/11.2/db/root.sh',
+             'command' => '/u01/app/oracle/product/11.2/db/root.sh',
              'group'   => 'root',
            }).that_requires('Exec[install oracle database 11.2.0.4_Linux-x86-64]')
       end
@@ -262,19 +262,19 @@ describe 'oradb::installdb', :type => :define do
 
   describe "CentOS unpacked" do
     let(:params){{
-          :version                 => '11.2.0.3',
-          :file                    => 'p10404530_112030_Linux-x86-64',
-          :database_type            => 'EE',
-          :oracle_base              => '/oracle',
-          :oracle_home              => '/oracle/product/11.2/db',
-          :user                    => 'oracle',
-          :group                   => 'dba',
-          :group_install           => 'oinstall',
-          :group_oper              => 'oper',
-          :remote_file              => false,
-          :zip_extract              => false,
-          :download_dir             => '/mnt',
-          :puppet_download_mnt_point  => '/software',
+          :version                   => '11.2.0.3',
+          :file                      => 'p10404530_112030_Linux-x86-64',
+          :database_type             => 'EE',
+          :oracle_base               => '/u01/app/oracle',
+          :oracle_home               => '/u01/app/oracle/product/11.2/db',
+          :user                      => 'oracle',
+          :group                     => 'dba',
+          :group_install             => 'oinstall',
+          :group_oper                => 'oper',
+          :remote_file               => false,
+          :zip_extract               => false,
+          :download_dir              => '/mnt',
+          :puppet_download_mnt_point => '/software',
                 }}
     let(:title) {'11.2.0.3_Linux-x86-64'}
     let(:facts) {{ :operatingsystem => 'OracleLinux' ,
@@ -285,12 +285,12 @@ describe 'oradb::installdb', :type => :define do
     describe "oradb utils structure" do
       it do
         should contain_db_directory_structure("oracle structure 11.2.0.3").with({
-              'ensure'                => 'present',
-              'oracle_base_dir'       => '/oracle',
-              'ora_inventory_dir'     => '/oracle/../oraInventory',
-              'os_user'               => 'oracle',
-              'os_group'              => 'oinstall',
-              'download_dir'          => '/mnt',
+              'ensure'            => 'present',
+              'oracle_base_dir'   => '/u01/app/oracle',
+              'ora_inventory_dir' => '/u01/app/oraInventory',
+              'os_user'           => 'oracle',
+              'os_group'          => 'oinstall',
+              'download_dir'      => '/mnt',
            })
       end
     end
@@ -298,8 +298,8 @@ describe 'oradb::installdb', :type => :define do
     describe "oradb orainst" do
       it do
         should contain_oradb__utils__dborainst('database orainst 11.2.0.3').with({
-             'ora_inventory_dir'  => '/oracle/../oraInventory',
-             'os_group'           => 'oinstall',
+             'ora_inventory_dir' => '/u01/app/oraInventory',
+             'os_group'          => 'oinstall',
            })
       end
     end
@@ -314,7 +314,7 @@ describe 'oradb::installdb', :type => :define do
       it {
            should contain_exec("install oracle database 11.2.0.3_Linux-x86-64").with({
              'command'  => "/bin/sh -c 'unset DISPLAY;/mnt/p10404530_112030_Linux-x86-64/database/runInstaller -silent -waitforcompletion -ignoreSysPrereqs -ignorePrereq -responseFile /mnt/db_install_11.2.0.3.rsp'",
-             'creates'  => "/oracle/product/11.2/db/dbs",
+             'creates'  => "/u01/app/oracle/product/11.2/db/dbs",
              'group'    => 'oinstall',
            }).that_requires('Oradb::Utils::Dborainst[database orainst 11.2.0.3]').that_requires('File[/mnt/db_install_11.2.0.3.rsp]')
          }
@@ -322,7 +322,7 @@ describe 'oradb::installdb', :type => :define do
 
     describe "oracle home" do
       it do
-        should contain_file("/oracle/product/11.2/db").with({
+        should contain_file("/u01/app/oracle/product/11.2/db").with({
              'ensure'  => 'directory',
              'owner'   => 'oracle',
              'group'   => 'oinstall',
@@ -342,7 +342,7 @@ describe 'oradb::installdb', :type => :define do
     describe "exec root.sh" do
       it do
         should contain_exec("run root.sh script 11.2.0.3_Linux-x86-64").with({
-             'command' => '/oracle/product/11.2/db/root.sh',
+             'command' => '/u01/app/oracle/product/11.2/db/root.sh',
              'group'   => 'root',
            }).that_requires('Exec[install oracle database 11.2.0.3_Linux-x86-64]')
       end

--- a/spec/defines/installdb_remote_spec.rb
+++ b/spec/defines/installdb_remote_spec.rb
@@ -76,6 +76,11 @@ describe 'oradb::installdb', :type => :define do
           /"not_an_absolute_path" is not an absolute path/
       end
     end
+    context 'with oracle base = /oracle' do
+      params = default_params.merge( { :oracle_base => '/oracle' } )
+      let(:params) { params }
+      it { is_expected.to contain_db_directory_structure("oracle structure 12.1.0.1").with_ora_inventory_dir('/oraInventory') }
+    end
 
     describe "oradb response file" do
       it do

--- a/spec/functions/oradb_cleanpath_spec.rb
+++ b/spec/functions/oradb_cleanpath_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
+
+describe 'oradb_cleanpath', :type => :puppet_function do
+
+  context 'with valid parameters' do
+    it { is_expected.to run.with_params('/u01/app/oracle/../oraInventory').and_return('/u01/app/oraInventory') }
+  end
+
+  context 'With invalid parameters' do
+    describe 'with wrong number of parameters' do
+      it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /oradb_cleanpath requires exactly 1 argument/ ) }
+      it { is_expected.to run.with_params('a','b').and_raise_error(Puppet::ParseError, /oradb_cleanpath requires exactly 1 argument/ ) }
+    end
+    describe 'with non string parameter' do
+      it { is_expected.to run.with_params(['a']).and_raise_error(Puppet::ParseError, /oradb_cleanpath requires a string argument/ ) }
+      it { is_expected.to run.with_params(false).and_raise_error(Puppet::ParseError, /oradb_cleanpath requires a string argument/ ) }
+      it { is_expected.to run.with_params(42).and_raise_error(Puppet::ParseError,    /oradb_cleanpath requires a string argument/ ) }
+    end
+  end
+end


### PR DESCRIPTION
I probably would like to do a bit more testing before this is merged.

I think the current default for the Oracle Inventory path is basically incorrect.
These 2 commits fix this.  See individual commit messages for more details.

I think it's safe for existing users who've already run puppet.  This commit didn't change any resources on the system I tested on, as by default it uses the oradb_inst_loc_data fact if available.