### PR TITLE
RCU password

### DIFF
--- a/lib/puppet/provider/db_rcu/db_rcu.rb
+++ b/lib/puppet/provider/db_rcu/db_rcu.rb
@@ -53,7 +53,8 @@ EOS
     FileUtils.chmod(0555, tmpFile.path)
 
     Puppet.debug "rcu for prefix #{prefix} execute SQL"
-    output = `su - #{user} -c 'export ORACLE_HOME=#{oracle_home};LD_LIBRARY_PATH=#{oracle_home}/lib #{oracle_home}/bin/sqlplus \"#{sys_user}/#{sys_password}@//#{db_server}/#{db_service} as sysdba\" @#{tmpFile.path}'`
+    output = system('su', '-', user, '-c', 'export', 'ORACLE_HOME=#{oracle_home};LD_LIBRARY_PATH=#{oracle_home}/lib',
+                    "#{oracle_home}/bin/sqlplus", " \"#{sys_user}/'#{sys_password}'@//#{db_server}/#{db_service} as sysdba\"", "@#{tmpFile.path}")
     raise ArgumentError, "Error executing puppet code, #{output}" if $? != 0
 
     if FileTest.exists?("/tmp/check_rcu_#{prefix}2.txt")


### PR DESCRIPTION
Changed backticks for system call due to single quote and escape supression.
Added single quotes around db user password to prevent characters such as $ from causing connections to fail