### PR TITLE
allow service name to be configurable

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,8 @@
+# Use this file to instruct puppet-lint to ignore certain checks.
+# For the complete list of checks and flags to disable them,
+# refer to <http://puppet-lint.com/checks/>.
+
+# Examples (uncomment before use):
+#--no-80chars-check
+#--no-class_inherits_from_params_class-check
+#--no-inherits_across_namespaces-check

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ platform :ruby_19, :ruby_20 do
   gem 'coveralls', :require => false
   gem 'simplecov', :require => false
 end
+gem 'rspec-puppet-utils', :git => 'https://github.com/Accuity/rspec-puppet-utils.git'
+gem 'hiera-puppet-helper', :git => 'https://github.com/bobtfish/hiera-puppet-helper.git'
 gem 'puppet-lint'
 gem 'puppet', puppetversion
 gem 'rspec-puppet'

--- a/spec/classes/prepareautostart_spec.rb
+++ b/spec/classes/prepareautostart_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+require 'shared_contexts'
+
+describe 'oradb::prepareautostart' do
+  # by default the hiera integration uses hiera data from the shared_contexts.rb file
+  # but basically to mock hiera you first need to add a key/value pair
+  # to the specific context in the spec/shared_contexts.rb file
+  # Note: you can only use a single hiera context per describe/context block
+  # rspec-puppet does not allow you to swap out hiera data on a per test block
+  #include_context :hiera
+
+  
+  # below is the facts hash that gives you the ability to mock
+  # facts on a per describe/context block.  If you use a fact in your
+  # manifest you should mock the facts below.
+  let(:facts) do
+    {}
+  end
+  # below is a list of the resource parameters that you can override.
+  # By default all non-required parameters are commented out,
+  # while all required parameters will require you to add a value
+  let(:params) do
+    {
+      #:oracle_home => undef,
+      #:user => "oracle",
+      :service_name => "oracle",
+    }
+  end
+  # add these two lines in a single test block to enable puppet and hiera debug mode
+  # Puppet::Util::Log.level = :debug
+  # Puppet::Util::Log.newdestination(:console)
+  describe 'Solaris' do
+    let(:facts) do
+      {
+        :kernel => 'SunOS',
+        :operatingsystem => 'Solaris',
+      }
+    end
+
+    it do
+      is_expected.to contain_file('/etc/oracle')
+         .with(
+           'ensure'  => 'present',
+           'mode'    => '0755',
+           'owner'   => 'root'
+         )
+    end
+    it do
+      is_expected.to contain_file('/tmp/oradb_smf.xml')
+        .with(
+          'ensure' => 'present',
+          'mode'   => '0755',
+          'owner'  => 'root',
+          'content' => /\/etc\/oracle/
+        )
+    end
+
+    it do
+      is_expected.to contain_exec('enable service oracle')
+        .with(
+          'command'   => 'svccfg -v import /tmp/oradb_smf.xml',
+          'user'      => 'root',
+          'logoutput' => true,
+          'path'      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:',
+          'unless'    => 'svccfg list | grep oracledatabase',
+          'require'   => ['File[/tmp/oradb_smf.xml]','File[/etc/oracle]'],
+        )
+    end
+  end
+
+  describe 'Linux' do
+    let(:facts) do
+      {:kernel => 'Linux', :operatingsystem => 'RedHat'}
+    end
+
+    it do
+      is_expected.to contain_file('/etc/init.d/oracle')
+         .with(
+           'content' => /LOCK_FILE=\/var\/lock\/subsys\/oracle/,
+           'ensure'  => 'present',
+           'mode'    => '0755',
+           'owner'   => 'root'
+         )
+    end
+    rhel_based = ['CentOS', 'RedHat', 'OracleLinux', 'SLES']
+    deb_based = ['Ubuntu', 'Debian']
+    rhel_based.each do |os|
+      describe os do
+        let(:facts) do
+          {
+
+            :kernel => 'Linux',
+            :operatingsystem => os
+          }
+
+        end
+
+        it do
+          is_expected.to contain_exec('enable service oracle')
+             .with(
+               'command'   => "chkconfig --add oracle",
+               'require'   => 'File[/etc/init.d/oracle]',
+               'user'      => 'root',
+               'unless'    => "chkconfig --list | /bin/grep \'oracle\'",
+               'path'      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:',
+               'logoutput' => true,
+             )
+        end
+      end
+    end
+    deb_based.each do |os|
+      describe os do
+        let(:facts) do
+          {
+            :kernel => 'Linux',
+            :operatingsystem => os
+          }
+
+        end
+
+        it do
+          is_expected.to contain_exec('enable service oracle')
+               .with(
+                 'command'   => "update-rc.d oracle defaults",
+                 'require'   => 'File[/etc/init.d/oracle]',
+                 'user'      => 'root',
+                 'unless'    => "ls /etc/rc3.d/*oracle | /bin/grep \'oracle\'",
+                 'path'      => '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:',
+                 'logoutput' => true,
+               )
+        end
+      end
+    end
+  end
+end

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -1,0 +1,46 @@
+# optional, this should be the path to where the hiera data config file is in this repo
+# You must update this if your actual hiera data lives inside your module.
+# I only assume you have a separate repository for hieradata and its include in your .fixtures
+hiera_config_file = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures','modules','hieradata', 'hiera.yaml'))
+
+# hiera_config and hiera_data are mutually exclusive contexts.
+
+shared_context :global_hiera_data do
+  let(:hiera_data) do
+     {
+       #"oradb::prepareautostart::oracle_home" => '',
+       #"oradb::prepareautostart::user" => '',
+       #"oradb::shout" => '',
+     
+     }
+  end
+end
+
+shared_context :hiera do
+    # example only,
+    let(:hiera_data) do
+        {:some_key => "some_value" }
+    end
+end
+
+shared_context :linux_hiera do
+    # example only,
+    let(:hiera_data) do
+        {:some_key => "some_value" }
+    end
+end
+
+# In case you want a more specific set of mocked hiera data for windows
+shared_context :windows_hiera do
+    # example only,
+    let(:hiera_data) do
+        {:some_key => "some_value" }
+    end
+end
+
+# you cannot use this in addition to any of the hiera_data contexts above
+shared_context :real_hiera_data do
+    let(:hiera_config) do
+       hiera_config_file
+    end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,49 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-utils'
+# if your using puppet4, the following gem seems to causes issues
+require 'hiera-puppet-helper'
+
 begin
-  require 'coveralls'
-  Coveralls.wear!
+    require 'coveralls'
+    Coveralls.wear!
 
 rescue LoadError
-  puts "No Coveralls support"
+    puts "No Coveralls support"
 end
 
-require 'rspec-puppet'
-require 'puppetlabs_spec_helper/module_spec_helper'
-fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+# Uncomment this to show coverage report, also useful for debugging
+#at_exit { RSpec::Puppet::Coverage.report! }
+
+#set to "yes" to enable the future parser, the equivalent of setting parser=future in puppet.conf.
+#ENV['FUTURE_PARSER'] = 'yes'
+
+# set to "yes" to enable strict variable checking, the equivalent of setting strict_variables=true in puppet.conf.
+#ENV['STRICT_VARIABLES'] = 'yes'
+
+# set to the desired ordering method ("title-hash", "manifest", or "random") to set the order of unrelated resources
+# when applying a catalog. Leave unset for the default behavior, currently "random". This is equivalent to setting
+# ordering in puppet.conf.
+#ENV['ORDERING'] = 'random'
+
+# set to "no" to enable structured facts, otherwise leave unset to retain the current default behavior.
+# This is equivalent to setting stringify_facts=false in puppet.conf.
+#ENV['STRINGIFY_FACTS']  = 'no'
+
+# set to "yes" to enable the $facts hash and trusted node data, which enabled $facts and $trusted hashes.
+# This is equivalent to setting trusted_node_data=true in puppet.conf.
+#ENV['TRUSTED_NODE_DATA'] = 'yes'
+
 # include common helpers
+
 support_path = File.expand_path(File.join(File.dirname(__FILE__), '..','spec/support/*.rb'))
 Dir[support_path].each {|f| require f}
 
-RSpec.configure do |c|
-  c.config = '/doesnotexist'
-  c.module_path  = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures/modules'))
-  c.manifest_dir = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures/manifests'))
+def param_value(subject, type, title, param)
+    subject.resource(type, title).send(:parameters)[param.to_sym]
 end
 
-def param_value(subject, type, title, param)
-  subject.resource(type, title).send(:parameters)[param.to_sym]
+RSpec.configure do |c|
+    c.formatter = 'documentation'
+    c.mock_with :rspec
+    c.config = '/doesnotexist'
 end

--- a/templates/dbora_Linux.erb
+++ b/templates/dbora_Linux.erb
@@ -10,6 +10,7 @@
 
 ORA_HOME=<%= @oracle_home %>
 ORA_OWNER=<%= @user %>
+LOCK_FILE=/var/lock/subsys/<%= @service_name %>
 
 if [ ! -f $ORA_HOME/bin/dbstart ]
 then
@@ -24,7 +25,7 @@ case "$1" in
         # will not prompt the user for any values
         #su $ORA_OWNER -c "$ORA_HOME/bin/lsnrctl start"
         su $ORA_OWNER -c "$ORA_HOME/bin/dbstart $ORA_HOME"
-        touch /var/lock/subsys/dbora
+        touch $LOCK_FILE
         ;;
     'stop')
         # Stop the Oracle databases:
@@ -32,6 +33,6 @@ case "$1" in
         # will not prompt the user for any values
         su $ORA_OWNER -c "$ORA_HOME/bin/dbshut $ORA_HOME"
         #su $ORA_OWNER -c "$ORA_HOME/bin/lsnrctl stop"
-        rm -f /var/lock/subsys/dbora
+        rm -f $LOCK_FILE
         ;;
 esac

--- a/templates/oradb_smf.xml.erb
+++ b/templates/oradb_smf.xml.erb
@@ -13,9 +13,9 @@
             <service_fmri value="svc:/milestone/multi-user"/>
         </dependency>
 
-        <exec_method type="method" name="start" exec="<%= @dboraLocation %>/dbora %m" timeout_seconds="500" />
-        <exec_method type="method" name="stop" exec="<%= @dboraLocation %>/dbora %m" timeout_seconds="500" />
-        <exec_method type="method" name="restart" exec="<%= @dboraLocation %>/dbora %m" timeout_seconds="500" />
+        <exec_method type="method" name="start" exec="<%= @dboraLocation %>/<%= @service_name %> %m" timeout_seconds="500" />
+        <exec_method type="method" name="stop" exec="<%= @dboraLocation %>/<%= @service_name %> %m" timeout_seconds="500" />
+        <exec_method type="method" name="restart" exec="<%= @dboraLocation %>/<%= @service_name %> %m" timeout_seconds="500" />
 
         <instance enabled="true" name="default"/>
         <template>


### PR DESCRIPTION
  * adds unit tests for prepareautostart
  * update gemfile to comply with spec helper after running retrospec
  * adds ability to mock hiera data
  * previously this class hard coded the service name to dbora
    in some situations like mine I wanted the service name to be oracle
    instead and this commit fixes that issue.
  * Note: because this class does not utilize the service resource
          there may be some conflicts or race conditions with
	  enabling/disabling the service if you the user declares
	  a service resource somewhere else in the catalog.