### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 spec/reports
 pkg
+.DS_Store


### PR DESCRIPTION
Recent Puppet Forge releases of oradb contain .DS_Store files that end
up being synced to all agents during plugin_sync.

I don't suppose this is a massive issue, but by adding .DS_Store to
.gitignore it shouldn't happen in future releases.
https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#set-files-to-be-ignored