### PR TITLE
[installasm] Add disk_au_size parameter to installasm

### DIFF
--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -20,6 +20,7 @@ define oradb::installasm(
   $asm_diskgroup             = 'DATA',
   $disk_discovery_string     = undef,
   $disk_redundancy           = 'NORMAL',
+  $disk_au_size              = 1,
   $disks                     = undef,
   $download_dir              = '/install',
   $zip_extract                = true,
@@ -34,6 +35,12 @@ define oradb::installasm(
 )
 {
 
+  case $disk_au_size {
+    1, 2, 4, 8, 16, 32, 64: {  } # Do nothing. These are valid values
+    default: {
+      fail("${disk_au_size} is an invalid disk_au_size. It needs to be one of these values: 1, 2, 4, 8, 16, 32, 64")
+    }
+  }
   $file_without_ext = regsubst($file, '(.+?)(\.zip*$|$)', '\1')
   #notify {"oradb::installasm file without extension ${$file_without_ext} ":}
 

--- a/spec/defines/installasm_params_spec.rb
+++ b/spec/defines/installasm_params_spec.rb
@@ -92,6 +92,37 @@ describe 'oradb::installasm', :type => :define do
       expect { should contain_notify("oradb::installasm /app/grid/product/11.2/grid does not exists")
              }.to raise_error(Puppet::Error, /Unrecognized database grid type, please use CRS_CONFIG|HA_CONFIG|UPGRADE/)
     end
+  end
+
+  describe "wrong disk_au_size" do
+    let(:params){{
+          :version                 => '11.2.0.4',
+          :file                    => 'p13390677_112040_Linux-x86-64_3of7.zip',
+          :grid_type                => 'XXXX',
+          :grid_base                => '/app/grid',
+          :grid_home                => '/app/grid/product/11.2/grid',
+          :remote_file              => false,
+          :download_dir             => '/install',
+          :puppet_download_mnt_point  => '/software',
+          :user_base_dir             => '/home',
+          :user                    => 'grid',
+          :group                   => 'asmdba',
+          :group_install           => 'oinstall',
+          :group_oper              => 'asmoper',
+          :group_asm               => 'asmadmin',
+          :sys_asm_password        => 'Welcome01',
+          :asm_monitor_password    => 'Welcome01',
+          :disk_au_size            => 200,
+                }}
+    let(:title) {'11.2.0.4_Linux-x86-64'}
+    let(:facts) {{ :operatingsystem => 'CentOS' ,
+                   :kernel          => 'Linux',
+                   :osfamily        => 'RedHat' }}
+
+    it do
+      expect { should contain_notify("oradb::installasm /app/grid/product/11.2/grid does not exists")
+             }.to raise_error(Puppet::Error, /invalid disk_au_size/)
+    end
 
   end
 

--- a/templates/grid_install_11.2.0.4.rsp.erb
+++ b/templates/grid_install_11.2.0.4.rsp.erb
@@ -335,7 +335,7 @@ oracle.install.asm.diskGroup.redundancy=<%= @disk_redundancy %>
 # size unit is MB
 #
 #-------------------------------------------------------------------------------
-oracle.install.asm.diskGroup.AUSize=1
+oracle.install.asm.diskGroup.AUSize=<%= @disk_au_size %> 
 
 #-------------------------------------------------------------------------------
 # List of disks to create a ASM DiskGroup

--- a/templates/grid_install_12.1.0.1.rsp.erb
+++ b/templates/grid_install_12.1.0.1.rsp.erb
@@ -365,7 +365,7 @@ oracle.install.asm.diskGroup.redundancy=<%= @disk_redundancy %>
 # size unit is MB
 #
 #-------------------------------------------------------------------------------
-oracle.install.asm.diskGroup.AUSize=1
+oracle.install.asm.diskGroup.AUSize=<%= @disk_au_size %> 
 
 #-------------------------------------------------------------------------------
 # List of disks to create a ASM DiskGroup

--- a/templates/grid_install_12.1.0.2.rsp.erb
+++ b/templates/grid_install_12.1.0.2.rsp.erb
@@ -365,7 +365,7 @@ oracle.install.asm.diskGroup.redundancy=<%= @disk_redundancy %>
 # size unit is MB
 #
 #-------------------------------------------------------------------------------
-oracle.install.asm.diskGroup.AUSize=1
+oracle.install.asm.diskGroup.AUSize=<%= @disk_au_size %> 
 
 #-------------------------------------------------------------------------------
 # List of disks to create a ASM DiskGroup


### PR DESCRIPTION
This parameter allows you to specify the ASM au_size for the ASM disks created during installation.