### PR TITLE
Add oracle_hostname variable

### DIFF
--- a/manifests/installem_agent.pp
+++ b/manifests/installem_agent.pp
@@ -22,6 +22,7 @@ define oradb::installem_agent(
   $group                       = 'oinstall',
   $download_dir                = '/install',
   $log_output                  = false,
+  $oracle_hostname             = undef,
 )
 {
 
@@ -120,7 +121,7 @@ define oradb::installem_agent(
         require => Db_directory_structure["oracle em agent structure ${version}"],
       }
 
-      $command = "${download_dir}/AgentPull.sh LOGIN_USER=${sysman_user} LOGIN_PASSWORD=${sysman_password} PLATFORM=\"${install_platform}\" VERSION=${install_version} AGENT_BASE_DIR=${agent_base_dir} AGENT_REGISTRATION_PASSWORD=${agent_registration_password} RSPFILE_LOC=${download_dir}/em_agent.properties"
+      $command = "${download_dir}/AgentPull.sh LOGIN_USER=${sysman_user} LOGIN_PASSWORD=${sysman_password} PLATFORM=\"${install_platform}\" VERSION=${install_version} AGENT_BASE_DIR=${agent_base_dir} AGENT_REGISTRATION_PASSWORD=${agent_registration_password} ORACLE_HOSTNAME=${oracle_hostname} RSPFILE_LOC=${download_dir}/em_agent.properties"
 
       exec { "agentPull execute ${title}":
         command   => $command,


### PR DESCRIPTION
Add oracle_hostname variable to enter the fully qualified domain name of the host where you want to install the Management Agent.

