### PR TITLE
Fix database sample_schema default

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -23,7 +23,7 @@ define oradb::database(
   $character_set             = 'AL32UTF8',
   $nationalcharacter_set     = 'UTF8',
   $init_params               = undef,
-  $sample_schema             = TRUE,
+  $sample_schema             = 'TRUE',
   $memory_percentage         = '40',
   $memory_total              = '800',
   $database_type             = 'MULTIPURPOSE', # MULTIPURPOSE|DATA_WAREHOUSING|OLTP


### PR DESCRIPTION
With latest puppet, TRUE needs to be quoted.

Reproduce with `PUPPET_VERSION='4.5.2' bundle exec rake spec`

```
Failures:

  1) oradb::database wrong database version should raise Puppet::Error with message matching /Unrecognized version/
     Failure/Error:
       expect { should contain_file("/install/database_testDb_Create.rsp")
                }.to raise_error(Puppet::Error, /Unrecognized version/)

       expected Puppet::Error with message matching /Unrecognized version/, got #<Puppet::PreformattedError: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Resource type not found: TRUE at /home/alex/github/oradb/spec/fixtures/modules/oradb/manifests/database.pp:26:32
```
