### PR TITLE
allow specifying the temp directory in bash_profile and during client install

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -107,17 +107,18 @@ define oradb::client(
 
     # In $download_dir, will Puppet extract the ZIP files or is this a pre-extracted directory structure.
     exec { "install oracle client ${title}":
-      command   => "/bin/sh -c 'unset DISPLAY;${download_dir}/client_${version}/client/runInstaller -silent -waitforcompletion -ignoreSysPrereqs -ignorePrereq -responseFile ${download_dir}/db_client_${version}.rsp'",
-      require   => [Oradb::Utils::Dborainst["oracle orainst ${version}"],
-                    File["${download_dir}/db_client_${version}.rsp"],
-                    Exec["extract ${download_dir}/${file}"]],
-      creates   => $oracle_home,
-      timeout   => 0,
-      returns   => [6,0],
-      path      => $execPath,
-      user      => $user,
-      group     => $group_install,
-      logoutput => $logoutput,
+      command     => "/bin/sh -c 'unset DISPLAY;${download_dir}/client_${version}/client/runInstaller -silent -waitforcompletion -ignoreSysPrereqs -ignorePrereq -responseFile ${download_dir}/db_client_${version}.rsp'",
+      require     => [Oradb::Utils::Dborainst["oracle orainst ${version}"],
+                      File["${download_dir}/db_client_${version}.rsp"],
+                      Exec["extract ${download_dir}/${file}"]],
+      creates     => $oracle_home,
+      timeout     => 0,
+      returns     => [6,0],
+      path        => $execPath,
+      user        => $user,
+      group       => $group_install,
+      logoutput   => $logoutput,
+      environment => "TEMP=${temp_dir}",
     }
 
     exec { "run root.sh script ${title}":

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -17,6 +17,7 @@ define oradb::client(
   $puppet_download_mnt_point = undef,
   $remote_file               = true,
   $logoutput                 = true,
+  $temp_dir                  = '/tmp',
 )
 {
   validate_absolute_path($oracle_home)

--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -32,6 +32,7 @@ define oradb::installasm(
   $cluster_nodes             = undef,
   $network_interface_list    = undef,
   $storage_option            = undef,
+  $temp_dir                  = '/tmp',
 )
 {
 

--- a/manifests/installdb.pp
+++ b/manifests/installdb.pp
@@ -29,6 +29,7 @@ define oradb::installdb(
   $cluster_nodes             = undef,
   $cleanup_install_files     = true,
   $is_rack_one_install       = false,
+  $temp_dir                  = '/tmp',
 )
 {
   if ( $create_user == true ){

--- a/templates/bash_profile.erb
+++ b/templates/bash_profile.erb
@@ -14,6 +14,6 @@ export ORACLE_HOME
 export SQLPLUS_HOME
 export PATH
 
-export TEMP=/tmp
-export TMPDIR=/tmp
+export TEMP=<%= @temp_dir %>
+export TMPDIR=<%= @temp_dir %>
 umask 022

--- a/templates/grid_bash_profile.erb
+++ b/templates/grid_bash_profile.erb
@@ -22,6 +22,6 @@ export ORACLE_HOME
 export SQLPLUS_HOME
 export PATH
 
-export TEMP=/tmp
-export TMPDIR=/tmp
+export TEMP=<%= @temp_dir %>
+export TMPDIR=<%= @temp_dir %>
 umask 022


### PR DESCRIPTION
I am running this module to install the Oracle client on a server that has /tmp mounted with a noexec option (for security purposes) and the client installation fails with permission denied if I don't specify a different folder as the temp directory. 



For reference: [ssg rhel6 guide](http://people.redhat.com/swells/scap-security-guide/RHEL/6/output/ssg-rhel6-guide-C2S.html)
Add noexec Option to /tmp

The noexec mount option can be used to prevent binaries from being executed out of /tmp. Add the noexec option to the fourth column of /etc/fstab for the line which controls mounting of /tmp.

Rationale:
Allowing users to execute binaries from world-writable directories such as /tmp should never be necessary in normal operation and can expose the system to potential compromise.

CCE-26720-3