### PR TITLE
Handling 2 installation of the same oracledb version on the same servers

### DIFF
--- a/manifests/installdb.pp
+++ b/manifests/installdb.pp
@@ -215,14 +215,16 @@ define oradb::installdb(
       require   => Exec["install oracle database ${title}"],
     }
 
-    file { $oracle_home:
-      ensure  => directory,
-      recurse => false,
-      replace => false,
-      mode    => '0775',
-      owner   => $user,
-      group   => $group_install,
-      require => Exec["install oracle database ${title}","run root.sh script ${title}"],
+    if !defined(File["${oracle_home}"]) {
+      file { $oracle_home:
+        ensure  => directory,
+        recurse => false,
+        replace => false,
+        mode    => '0775',
+        owner   => $user,
+        group   => $group_install,
+        require => Exec["install oracle database ${title}","run root.sh script ${title}"],
+      }
     }
 
     # cleanup

--- a/manifests/installdb.pp
+++ b/manifests/installdb.pp
@@ -88,7 +88,7 @@ define oradb::installdb(
     $oraInventory = "${ora_inventory_dir}/oraInventory"
   }
 
-  db_directory_structure{"oracle structure ${version}":
+  db_directory_structure{"oracle structure ${version}_${title}":
     ensure            => present,
     oracle_base_dir   => $oracle_base,
     ora_inventory_dir => $oraInventory,
@@ -120,7 +120,7 @@ define oradb::installdb(
           mode    => '0775',
           owner   => $user,
           group   => $group,
-          require => Db_directory_structure["oracle structure ${version}"],
+          require => Db_directory_structure["oracle structure ${version}_${title}"],
           before  => Exec["extract ${download_dir}/${file1}"],
         }
         # db file 2 installer zip
@@ -145,7 +145,7 @@ define oradb::installdb(
         path      => $execPath,
         user      => $user,
         group     => $group,
-        require   => Db_directory_structure["oracle structure ${version}"],
+        require   => Db_directory_structure["oracle structure ${version}_${title}"],
         before    => Exec["install oracle database ${title}"],
       }
       exec { "extract ${download_dir}/${file2}":
@@ -160,25 +160,25 @@ define oradb::installdb(
       }
     }
 
-    oradb::utils::dborainst{"database orainst ${version}":
+    oradb::utils::dborainst{"database orainst ${version}_${title}":
       ora_inventory_dir => $oraInventory,
       os_group          => $group_install,
     }
 
-    if ! defined(File["${download_dir}/db_install_${version}.rsp"]) {
-      file { "${download_dir}/db_install_${version}.rsp":
+    if ! defined(File["${download_dir}/db_install_${version}_${title}.rsp"]) {
+      file { "${download_dir}/db_install_${version}_${title}.rsp":
         ensure  => present,
         content => template("oradb/db_install_${version}.rsp.erb"),
         mode    => '0775',
         owner   => $user,
         group   => $group,
-        require => [Oradb::Utils::Dborainst["database orainst ${version}"],
-                    Db_directory_structure["oracle structure ${version}"],],
+        require => [Oradb::Utils::Dborainst["database orainst ${version}_${title}"],
+                    Db_directory_structure["oracle structure ${version}_${title}"],],
       }
     }
 
     exec { "install oracle database ${title}":
-      command     => "/bin/sh -c 'unset DISPLAY;${download_dir}/${file}/database/runInstaller -silent -waitforcompletion -ignoreSysPrereqs -ignorePrereq -responseFile ${download_dir}/db_install_${version}.rsp'",
+      command     => "/bin/sh -c 'unset DISPLAY;${download_dir}/${file}/database/runInstaller -silent -waitforcompletion -ignoreSysPrereqs -ignorePrereq -responseFile ${download_dir}/db_install_${version}_${title}.rsp'",
       creates     => "${oracle_home}/dbs",
       environment => ["USER=${user}","LOGNAME=${user}"],
       timeout     => 0,
@@ -188,8 +188,8 @@ define oradb::installdb(
       group       => $group_install,
       cwd         => $oracle_base,
       logoutput   => true,
-      require     => [Oradb::Utils::Dborainst["database orainst ${version}"],
-                      File["${download_dir}/db_install_${version}.rsp"]],
+      require     => [Oradb::Utils::Dborainst["database orainst ${version}_${title}"],
+                      File["${download_dir}/db_install_${version}_${title}.rsp"]],
     }
 
     if ( $bash_profile == true ) {


### PR DESCRIPTION
Changed some reference from ${version] to ${title}_${version} so it's possible to have 2 installation of the same version of Oracle Database on the same server.
It work correctly and install 2 oracle version in different home.

facter after installation of 2 oracle server and 1 oracle client:

> oradb_inst_loc_data => /oracle/orainv/oraInventory
> oradb_inst_opatch_oracle_product_12.1_client => 12.1.0.1.3
> oradb_inst_opatch_oracle_product_12.1_db1 => 12.1.0.1.3
> oradb_inst_opatch_oracle_product_12.1_db2 => 12.1.0.1.3
> oradb_inst_products => /oracle/product/12.1/db2;/oracle/product/12.1/db1;/oracle/product/12.1/client;
 
inventory.xml reports those oracle homes:

```

<HOME_LIST>
<HOME NAME="OraDB12Home1" LOC="/oracle/product/12.1/db2" TYPE="O" IDX="1"/>
<HOME NAME="OraDB12Home2" LOC="/oracle/product/12.1/db1" TYPE="O" IDX="2"/>
<HOME NAME="OraClient12Home1" LOC="/oracle/product/12.1/client" TYPE="O" IDX="3"/>
</HOME_LIST>

```

Related to #128
