### PR TITLE
Add `opatch_patches` structured fact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.lock
 coverage
 spec/reports
+spec/fixtures
 pkg
 .DS_Store

--- a/lib/facter/oracle_database_homes.rb
+++ b/lib/facter/oracle_database_homes.rb
@@ -45,6 +45,17 @@ def get_opatch_version(name)
   opatchver
 end
 
+def get_opatch_patches(name)
+  opatch_out = Facter::Util::Resolution.exec(get_su_command + get_database_user + ' -c "' + name + '/OPatch/opatch lspatches"')
+  return nil if opatch_out.nil?
+
+  opatch_out.each_line.collect do |line|
+    next unless line =~ /^\d+;/
+    split_line = line.split(';')
+    { :patch_id => split_line[0], :patch_desc => split_line[1].chomp }
+  end.compact
+end
+
 def get_orainst_loc
   if FileTest.exists?(get_ora_inv_path + '/oraInst.loc')
     str = ''
@@ -65,7 +76,8 @@ def get_orainst_products(path)
     if FileTest.exists?(path + '/ContentsXML/inventory.xml')
       file = File.read(path + '/ContentsXML/inventory.xml')
       doc = REXML::Document.new file
-      software =  ''
+      software = ''
+      patches_fact = {}
       doc.elements.each('/INVENTORY/HOME_LIST/HOME') do |element|
         str = element.attributes['LOC']
         unless str.nil?
@@ -84,8 +96,13 @@ def get_orainst_products(path)
                 opatchver
               end
             end
+            patches = get_opatch_patches(str)
+            patches_fact[str] = patches unless patches.nil?
           end
         end
+      end
+      Facter.add('opatch_patches') do
+        setcode { patches_fact }
       end
       return software
     else

--- a/lib/puppet/parser/functions/is_oracle_patch_installed.rb
+++ b/lib/puppet/parser/functions/is_oracle_patch_installed.rb
@@ -1,0 +1,22 @@
+module Puppet::Parser::Functions
+  newfunction(:is_oracle_patch_installed, :type => :rvalue, :doc => <<-EOS
+  Takes 2 parameters, the oracle_home and the patch_id.
+  Returns true if the patch_id is installed in the oracle_home.
+EOS
+             ) do |args|
+    raise(Puppet::ParseError, 'is_oracle_patch_installed(): Wrong number of arguments') unless args.size == 2
+
+    oracle_home = args[0]
+    raise(Puppet::ParseError, 'oracle_home must be absolute path') unless function_is_absolute_path([oracle_home])
+
+    patch_id = args[1]
+    raise(Puppet::ParseError, 'patch_id must be a string')           unless patch_id.is_a?(String)
+    raise(Puppet::ParseError, 'patch_id must be a string of digits') unless patch_id =~ /^\d+$/
+
+    patches = lookupvar('opatch_patches')
+    return false if patches.nil?
+    return false unless patches.key?(oracle_home)
+    return true if patches[oracle_home].find { |h| h['patch_id'] == patch_id }
+    return false
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0"
+      "version_requirement": ">= 4.11.0 < 5.0.0"
     }
   ],
   "license": "Apache-2.0",

--- a/spec/functions/is_oracle_patch_installed_spec.rb
+++ b/spec/functions/is_oracle_patch_installed_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
+
+describe 'is_oracle_patch_installed', :type => :puppet_function do
+  context 'when opatch_patches fact available' do
+    let(:facts) do
+      {
+        :opatch_patches => {
+          '/u01/app/oracle/product/12.1.0/dbhome_1' => [
+            {
+              :patch_id => '21485069',
+              :patch_desc => ''
+            },
+            {
+              :patch_id => '21948354',
+              :patch_desc => 'Database Patch Set Update : 12.1.0.2.160119 (21948354)'
+            }
+          ]
+        }
+      }
+    end
+    context 'when patch is installed in oracle_home' do
+      it { is_expected.to run.with_params('/u01/app/oracle/product/12.1.0/dbhome_1', '21948354').and_return(true) }
+    end
+    context 'when oracle_home is not in opatch_patches fact' do
+      it { is_expected.to run.with_params('/u01/app/oracle/product/12.1.0/no_such_home', '21948354').and_return(false) }
+    end
+    context 'when patch is not installed in oracle_home' do
+      it { is_expected.to run.with_params('/u01/app/oracle/product/12.1.0/dbhome_1', '666666').and_return(false) }
+    end
+  end
+  context 'when no opatch_patches fact' do
+    it { is_expected.to run.with_params('/u01/app/oracle/product/12.1.0/dbhome_1', '21948354').and_return(false) }
+  end
+
+  context 'with invalid parameters' do
+    describe 'with wrong number of parameters' do
+      it do
+        is_expected.to run.with_params
+          .and_raise_error(Puppet::ParseError, /is_oracle_patch_installed\(\): Wrong number of arguments/)
+      end
+      it do
+        is_expected.to run.with_params('/u01/app/oracle/product/12.1.0/dbhome_1')
+          .and_raise_error(Puppet::ParseError, /is_oracle_patch_installed\(\): Wrong number of arguments/)
+      end
+    end
+
+    describe 'with invalid oracle_home' do
+      it do
+        is_expected.to run.with_params('not_an_absolute_path', '666666')
+          .and_raise_error(Puppet::ParseError, /oracle_home must be absolute path/)
+      end
+    end
+
+    describe 'with invalid patch_id' do
+      it do
+        is_expected.to run.with_params('/u01/app/oracle/product/12.1.0/dbhome_1', 6666)
+          .and_raise_error(Puppet::ParseError, /^patch_id must be a string$/)
+      end
+      it do
+        is_expected.to run.with_params('/u01/app/oracle/product/12.1.0/dbhome_1', 'invalid_string')
+          .and_raise_error(Puppet::ParseError, /^patch_id must be a string of digits$/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Useful if you need to know what patches have already been applied.
I've done this as a `structured fact` as Puppet 3 is EOL at the end of
the year and soon everyone will be using the `facts` hash that is
enabled by default in puppet 4.

Example output...
```
[root@host ~]# facter -p opatch_patches
{
  /u01/app/oracle/product/12.1.0/dbhome_1 => [
    {
      patch_id => "21485069",
      patch_desc => ""
    },
    {
      patch_id => "21948354",
      patch_desc => "Database Patch Set Update : 12.1.0.2.160119 (21948354)"
    }
  ]
}
```
Originally developed for just oracle database, but seems to work fine with weblogic too.
```
[root@host ~]# facter -p opatch_patches
{
  /u01/app/oracle/Middleware => [
    {
      patch_id => "23094292",
      patch_desc => ""
    }
  ]
}
```

Signed-off-by: Alexander Fisher <alex@linfratech.co.uk>