### PR TITLE
Resolve idempotence issue which happens when a patch from the same source needs to be applied multiple times

### DIFF
--- a/manifests/opatch.pp
+++ b/manifests/opatch.pp
@@ -48,8 +48,6 @@ define oradb::opatch(
           ensure => present,
           source => "${mountPoint}/${patch_file}",
           mode   => '0775',
-          owner  => $user,
-          group  => $group,
         }
       }
     }


### PR DESCRIPTION
This can happen when an Oracle patch need to be applied
to both the database home and the grid home