### PR TITLE
RCU fixes for running as non-root user

### DIFF
--- a/lib/puppet/provider/db_rcu/db_rcu.rb
+++ b/lib/puppet/provider/db_rcu/db_rcu.rb
@@ -12,7 +12,12 @@ Puppet::Type.type(:db_rcu).provide(:db_rcu) do
     # environment = "SQLPLUS_HOME=#{oracle_home}"
     Puppet.debug "rcu statement: #{statement}"
 
-    output = `su - #{user} -c '#{statement}'`
+    # stdin from password file is lost if running as oracle but try to su
+    if Puppet.features.root?
+      output = `su - #{user} -c '#{statement}'`
+    else
+      output = `#{statement}`
+    end
     # output = execute statement, :failonfail => true ,:uid => user, :custom_environment => environment
     Puppet.info "RCU result: #{output}"
     result = false

--- a/manifests/rcu.pp
+++ b/manifests/rcu.pp
@@ -81,11 +81,12 @@ define oradb::rcu(
     }
   }
 
-  if ! defined(File["${download_dir}/rcu_${version}/rcuHome/rcu/log"]) {
+  # rcuHome is read only for non-root user so put log dir above it
+  if ! defined(File["${download_dir}/rcu_${version}/log"]) {
     # check rcu log folder
-    file { "${download_dir}/rcu_${version}/rcuHome/rcu/log":
+    file { "${download_dir}/rcu_${version}/log":
       ensure  => directory,
-      path    => "${download_dir}/rcu_${version}/rcuHome/rcu/log",
+      path    => "${download_dir}/rcu_${version}/log",
       recurse => false,
       replace => false,
       require => Exec["extract ${rcu_file}"],
@@ -126,9 +127,9 @@ define oradb::rcu(
   }
 
   if ( $oracle_home != undef ) {
-    $preCommand    = "export SQLPLUS_HOME=${oracle_home};${download_dir}/rcu_${version}/rcuHome/bin/rcu -silent"
+    $preCommand    = "export SQLPLUS_HOME=${oracle_home};export RCU_LOG_LOCATION=${download_dir}/rcu_${version}/log;${download_dir}/rcu_${version}/rcuHome/bin/rcu -silent"
   } else {
-    $preCommand    = "${download_dir}/rcu_${version}/rcuHome/bin/rcu -silent"
+    $preCommand    = "export RCU_LOG_LOCATION=${download_dir}/rcu_${version}/log;${download_dir}/rcu_${version}/rcuHome/bin/rcu -silent"
   }
   $postCommand     = "-databaseType ORACLE -connectString ${db_server}:${db_service} -dbUser ${sys_user} -dbRole SYSDBA -schemaPrefix ${schema_prefix} ${components} "
   $passwordCommand = " -f < ${download_dir}/rcu_${version}/rcu_passwords_${title}.txt"


### PR DESCRIPTION
Fixes a couple of issues:
1) when you unzip RCU all directories have 750 permissions
dr-xr-x---  7 oracle dba 4096 Mar  8  2013 rcu
=> the root user can create a log directory in here but oracle can't
Fix is to put the log dir under the top level RCU dir (I thought about adding a log parameter but don't think it's really necessary as RCU only runs once at install time)

2) when you run rcu you redirect the passwords file: rcu... < passwords.txt
When su - oracle "command" the redirect seems to get lost when Puppet is running as oracle. Therefore I don't su if it's not root now.
