### PR TITLE
Db completion check

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -154,7 +154,7 @@ define oradb::database(
     }
     exec { "oracle database ${title}":
       command     => $command,
-      creates     => "${oracle_home}/dbs/spfile$db_name[0,8].ora",
+      creates     => "${oracle_home}/dbs/spfile${db_name[0,8]}.ora",
       timeout     => 0,
       path        => $execPath,
       user        => $user,

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -154,7 +154,7 @@ define oradb::database(
     }
     exec { "oracle database ${title}":
       command     => $command,
-      creates     => "${oracle_base}/admin/${db_name}",
+      creates     => "${oracle_home}/dbs/init${db_name}.ora",
       timeout     => 0,
       path        => $execPath,
       user        => $user,

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -154,7 +154,7 @@ define oradb::database(
     }
     exec { "oracle database ${title}":
       command     => $command,
-      creates     => "${oracle_home}/dbs/init${db_name}.ora",
+      creates     => "${oracle_home}/dbs/spfile$db_name[0,8].ora",
       timeout     => 0,
       path        => $execPath,
       user        => $user,


### PR DESCRIPTION
Changed check for successful creation of oracle database.

`${oracle_home}/dbs/spfile${db_name[0,8]}.ora` gets created further towards the end of the process. This means puppet will try again to run the exec if it failed originally but got as far as creating `${oracle_base}/admin/${db_name}` which seems to get created quite early.

Tested by me on 12.1 only so far.