### PR TITLE
Db creation exec

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -154,7 +154,7 @@ define oradb::database(
     }
     exec { "oracle database ${title}":
       command     => $command,
-      creates     => "${oracle_base}/admin/${db_name}",
+      creates     => "${oracle_home}/dbs/init${db_name}.ora",
       timeout     => 0,
       path        => $execPath,
       user        => $user,

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -134,31 +134,34 @@ define oradb::database(
     $templatename = undef
   }
 
+  $elevation_prefix = "su - $user -c \"/bin/ksh -c \\\""
+  $elevation_suffix = "\\\"\""
+
   if $action == 'create' {
     if ( $templatename ) {
       if ( $version == '11.2' or $container_database == false ) {
         if ( $cluster_nodes != undef) {
-          $command = "${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -characterSet ${character_set} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} -nodelist ${cluster_nodes} -variables ${template_variables}"
+          $command = "${elevation_prefix}${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -characterSet ${character_set} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} -nodelist ${cluster_nodes} -variables ${template_variables}${elevation_suffix}"
         } else {
-          $command = "${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -characterSet ${character_set} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} -variables ${template_variables}"
+          $command = "${elevation_prefix}${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -characterSet ${character_set} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} -variables ${template_variables}${elevation_suffix}"
         }
       } else {
         if( $cluster_nodes != undef) {
-          $command = "${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -characterSet ${character_set} -createAsContainerDatabase ${container_database} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} -nodelist ${cluster_nodes} -variables ${template_variables}"
+          $command = "${elevation_prefix}${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -characterSet ${character_set} -createAsContainerDatabase ${container_database} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} -nodelist ${cluster_nodes} -variables ${template_variables}${elevation_suffix}"
         } else {
-          $command = "${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -characterSet ${character_set} -createAsContainerDatabase ${container_database} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} -variables ${template_variables}"
+          $command = "${elevation_prefix}${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -characterSet ${character_set} -createAsContainerDatabase ${container_database} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} -variables ${template_variables}${elevation_suffix}"
         }
       }
     } else {
-      $command = "${oracle_home}/bin/dbca -silent -responseFile ${download_dir}/database_${sanitized_title}.rsp"
+      $command = "${elevation_prefix}${oracle_home}/bin/dbca -silent -responseFile ${download_dir}/database_${sanitized_title}.rsp${elevation_suffix}"
     }
     exec { "oracle database ${title}":
       command     => $command,
       creates     => "${oracle_home}/dbs/init${db_name}.ora",
       timeout     => 0,
       path        => $execPath,
-      user        => $user,
-      group       => $group,
+      user        => "root",
+      group       => "root",
       cwd         => $oracle_base,
       environment => ["USER=${user}",],
       logoutput   => true,


### PR DESCRIPTION
This pr suggests a change in how the `dbca` command gets executed. Instead of using puppet's exec it uses su as root.

Motivation for that is a problem I ran into:
The `"oracle database ${title}"` exec fails for me with this error in the error log file:

Location +FRA does not exist.

This happens although the ASM disk group FRA actually does exist. Funny thing is if I run the resulting command this exec uses manually with `sudo - oracle <command>` it works:

+FRA has enough space. Required space is 1024 MB , available space is 4000 MB.
File Validations Successful.

I've tried running this exec with all kinds of settings, tried running it with various environment variables set and unset, inside the exec and outside, etc. but nothing worked, until I ran it with the su command this PR suggests.

Could so far test only on 12.1

I'm making the assumption that korn shell is at /bin/ksh. That might need to get parametrized, but I don't have a wide enough range of OS's to test against.