### PR TITLE
fix dbca createDatabase (issue #197): using parameter storageType inv…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Version updates
+## 3.0.16
+- fix database.pp change parameter storage_type to optional, to use template file without parameter -datafileDestination (issue #197)
+
 ## 3.0.15
 - fix autostart and removed the hard dbora reference
 

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -119,7 +119,7 @@ define oradb::database(
   Integer $memory_total                                           = lookup('oradb::database::memory_total'),
   Enum['MULTIPURPOSE', 'DATA_WAREHOUSING', 'OLTP'] $database_type = lookup('oradb::database::database_type'),
   Enum['NONE', 'CENTRAL', 'LOCAL', 'ALL'] $em_configuration       = lookup('oradb::database::em_configuration'),
-  Enum['FS', 'CFS', 'ASM'] $storage_type                          = lookup('oradb::database::storage_type'),
+  Optional[Enum['FS', 'CFS', 'ASM']] $storage_type                = undef,
   String $asm_snmp_password                                       = lookup('oradb::default::password'),
   String $db_snmp_password                                        = lookup('oradb::default::password'),
   String $asm_diskgroup                                           = lookup('oradb::database::asm_diskgroup'),
@@ -152,7 +152,7 @@ define oradb::database(
     fail('Unrecognized emConfiguration')
   }
 
-  if ( $storage_type in lookup('oradb::instance_storage_type') == false ) {
+  if ( $storage_type != undef and  $storage_type in lookup('oradb::instance_storage_type') == false ) {
     fail('Unrecognized storageType')
   }
 
@@ -239,7 +239,7 @@ define oradb::database(
   }
 
   if ($version == '12.2' and $templatename != undef and $storage_type != undef and $data_file_destination == undef ) {
-    fail('data_file_destination is required on version 12.2 when storage_type and templaten are defined')
+    fail('data_file_destination is required on version 12.2 when storage_type and template are defined')
   }
 
   $elevation_prefix = "su - ${user} -c \"/bin/ksh -c \\\""
@@ -260,9 +260,9 @@ define oradb::database(
       }
 
       if ( $version == '11.2' or $container_database == false ) {
-        $command_pre = "${elevation_prefix}${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -sid ${db_name} -characterSet ${character_set} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} "
+        $command_pre = "${elevation_prefix}${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -sid ${db_name} -characterSet ${character_set} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -emConfiguration ${em_configuration} "
       } else {
-        $command_pre = "${elevation_prefix}${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -sid ${db_name} -characterSet ${character_set} -createAsContainerDatabase ${container_database} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -storageType ${storage_type} -emConfiguration ${em_configuration} "
+        $command_pre = "${elevation_prefix}${oracle_home}/bin/dbca -silent -createDatabase -templateName ${templatename} -gdbname ${globaldb_name} -sid ${db_name} -characterSet ${character_set} -createAsContainerDatabase ${container_database} -responseFile NO_VALUE -sysPassword ${sys_password} -systemPassword ${system_password} -dbsnmpPassword ${db_snmp_password} -asmsnmpPassword ${asm_snmp_password} -emConfiguration ${em_configuration} "
       }
 
       if ( $template_variables != undef) {
@@ -288,7 +288,14 @@ define oradb::database(
       } else {
         $command_nodes = ''
       }
-      $command = "${command_pre} ${command_data_file} ${command_var} ${command_init} ${command_nodes} ${elevation_suffix}"
+
+      if ( $storage_type != undef) {
+        $command_storage = " -storageType ${storage_type}"
+      } else {
+        $command_storage = ''
+      }
+
+      $command = "${command_pre} ${command_storage} ${command_data_file} ${command_var} ${command_init} ${command_nodes} ${elevation_suffix}"
 
     } else {
       if ( $version == '12.2' ) {
@@ -315,6 +322,8 @@ define oradb::database(
     } else {
       $command = "${oracle_home}/bin/dbca -silent -responseFile ${download_dir}/database_${sanitized_title}.rsp"
     }
+
+    
     exec { "oracle database ${title}":
       command     => $command,
       onlyif      => "ls ${oracle_base}/admin/${db_name}",


### PR DESCRIPTION
…olve the use of -datafileDestination parameter, they are linked.

in our case, 3 disks classes (C1 for redo,C2,C3 for datafiles never read....), we split datafiles locations to several mount points.
But dixit oracle -datafileDestination parameter override those in template file.
That's why all db files are created in the same directory -datafileDestination
changing the parameter storageType to optional allow us to use template files without datafileDestination.
tested on 11.2 12.1 12.2, logs are available.