### PR TITLE
Add hirea look up for oracle_hostname on oem agent install with a default for fqdn

### DIFF
--- a/manifests/installem_agent.pp
+++ b/manifests/installem_agent.pp
@@ -88,7 +88,7 @@ define oradb::installem_agent(
   String $group                                      = lookup('oradb::group_install'),
   String $download_dir                               = lookup('oradb::download_dir'),
   Boolean $log_output                                = false,
-  String $oracle_hostname                            = undef, # FQDN hostname where to install on
+  String $oracle_hostname                            = lookup('oradb::oracle_hostname',{default_value => $::fqdn}),
   Boolean $manage_curl                               = true,
 )
 {


### PR DESCRIPTION
Added the following for hiera lookups and defaults if one is not used to fqdn.  This should also now make it an optional parameter.   Also removed the comment as it is documented above. 