### PR TITLE
add user and groups to module oradb::opatch exec unzip so the files a…

### DIFF
--- a/manifests/opatch.pp
+++ b/manifests/opatch.pp
@@ -81,6 +81,8 @@ define oradb::opatch(
             require   => File["${download_dir}/${patch_file}"],
             creates   => "${download_dir}/${patch_id}",
             path      => $exec_path,
+            user      => $user,
+            group     => $group,
             logoutput => false,
             before    => Db_opatch["${patch_id} ${title}"],
           }

--- a/manifests/opatch.pp
+++ b/manifests/opatch.pp
@@ -81,7 +81,6 @@ define oradb::opatch(
             require   => File["${download_dir}/${patch_file}"],
             creates   => "${download_dir}/${patch_id}",
             path      => $exec_path,
-            user      => $user,
             group     => $group,
             logoutput => false,
             before    => Db_opatch["${patch_id} ${title}"],


### PR DESCRIPTION
fix unzip exec to run as users and groups that are passed as parameters for the case statement of 'Linux' and 'SunOS' 