### PR TITLE
Remove zip file after extraction and before installation to save space

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -227,7 +227,7 @@ define oradb::client(
         user    => 'root',
         group   => 'root',
         path    => $exec_path,
-        require => Exec["install oracle net ${title}"],
+        before  => Exec["install oracle client ${title}"],
       }
     }
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -228,6 +228,7 @@ define oradb::client(
         group   => 'root',
         path    => $exec_path,
         before  => Exec["install oracle client ${title}"],
+        require => Exec["extract ${download_dir}/${file}"],
       }
     }
 


### PR DESCRIPTION
The downloaded zip file uses quite some space and is no longer necessary after extraction to my understanding

https://github.com/biemond/biemond-oradb/issues/251