### PR TITLE
Fix enumeration of storage_option for 12.2.0.1 grid installations

### DIFF
--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -105,7 +105,7 @@ define oradb::installasm(
     if ( $cluster_nodes == undef or is_string($cluster_nodes) == false) {fail('You must specify cluster_nodes if cluster_name is defined') }
     if ( $network_interface_list == undef or is_string($network_interface_list) == false) {fail('You must specify network_interface_list if cluster_name is defined') }
     if ( $storage_option == undef or is_string($storage_option) == false) {fail('You must specify storage_option if cluster_name is defined') }
-    unless $storage_option in ['ASM_STORAGE', 'FILE_SYSTEM_STORAGE'] {fail 'storage_option must be either ASM_STORAGE of FILE_SYSTEM_STORAGE'}
+    unless $storage_option in ['ASM_STORAGE','FLEX_ASM_STORAGE','CLIENT_ASM_STORAGE','NEAR_ASM_STORAGE', 'FILE_SYSTEM_STORAGE'] {fail 'storage_option must be either ASM_STORAGE,FLEX_ASM_STORAGE,CLIENT_ASM_STORAGE,NEAR_ASM_STORAGE or FILE_SYSTEM_STORAGE'}
   }
 
   $supported_grid_versions = join( lookup('oradb::grid_versions'), '|')


### PR DESCRIPTION
Allow new storage_options as of Oracle 12.2.0.1.

Fixes grid installation error:
 - cvc-enumeration-valid: Value 'ASM_STORAGE' is not facet-valid with respect to enumeration '[FILE_SYSTEM_STORAGE, FLEX_ASM_STORAGE, CLIENT_ASM_STORAGE, NEAR_ASM_STORAGE]'. It must be a value from the enumeration.