### PR TITLE
Updating the version for dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.1.0 < 5.0.0"
+      "version_requirement": ">= 2.1.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 7.0.0"
     }
   ],
   "data_provider": "hiera",


### PR DESCRIPTION
 stdlib and concat are 6.2.0

This is a fix for https://github.com/biemond/biemond-oradb/issues/271