### PR TITLE
Support systemd on any Enterprise Linux version greater than or equal to 7

### DIFF
--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -345,7 +345,7 @@ define oradb::installasm(
     }
 
     # Enterprise Linux 7 and greater uses systemd for service control
-    if ($facts['osfamily'] == 'RedHat' and $facts['operatingsystemmajrelease'] >= '7'){
+    if ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] >= '7'){
       file {'/etc/systemd/system/oracle-ohasd.service':
         ensure  => 'file',
         content => epp('oradb/ohas.service.epp'),

--- a/manifests/installasm.pp
+++ b/manifests/installasm.pp
@@ -344,25 +344,20 @@ define oradb::installasm(
       }
     }
 
-    #because of RHEL7 uses systemd we need to create the service differently
-    if ($facts['osfamily'] == 'RedHat' and $facts['operatingsystemmajrelease'] == '7')
-    {
+    # Enterprise Linux 7 and greater uses systemd for service control
+    if ($facts['osfamily'] == 'RedHat' and $facts['operatingsystemmajrelease'] >= '7'){
       file {'/etc/systemd/system/oracle-ohasd.service':
         ensure  => 'file',
         content => epp('oradb/ohas.service.epp'),
         mode    => '0644',
         require => Exec["install oracle grid ${title}"],
-      } -> exec { 'daemon-reload for ohas':
-        command => '/bin/systemctl daemon-reload',
+        notify  => Exec['daemon-reload for ohas'],
       }
-      # ->
 
-      # service { 'ohas.service':
-      #   ensure => running,
-      #   enable => true,
-      #   before => Exec["run root.sh grid script ${title}"],
-      # }
-
+      exec { 'daemon-reload for ohas':
+        command     => '/bin/systemctl daemon-reload',
+        refreshonly => true,
+      }
     }
 
     exec { "run root.sh grid script ${title}":


### PR DESCRIPTION
Currently, the installasm class only creates a systemd unit file on EL 7.  This should support 7 and greater.

I could further clean this up by utilizing the [puppet-systemd](https://forge.puppet.com/modules/puppet/systemd#unit-files) module to create the unit file and enable the service:

`$ohasd_systemd_ensure = $facts['systemd'] ? {
  true    => 'present',
  default => 'absent',
}

systemd::unit_file { 'oracle-ohasd':
  ensure  => $ohasd_systemd_ensure,
  source  => epp('oradb/ohas.service.epp'),
  enable  => true,
  active  => true,
  require => Exec["install oracle grid ${title}"],
}`

If you agree with further cleaning up and using the systemd forge module, I'll add an additional commit replacing it.