### PR TITLE
Set a default protocol to TCP when no protocol is specified.

### DIFF
--- a/templates/tnsnames.epp
+++ b/templates/tnsnames.epp
@@ -10,7 +10,7 @@
   (DESCRIPTION =
   <%- if $size == 1 { -%>
     <%- $server.each |$key, $server2| { -%>
-    (ADDRESS = (PROTOCOL = <%= $server2['protocol'] %>)(HOST = <%= $server2['host'] %>)(PORT = <%= $server2['port'] %>))
+    (ADDRESS = (PROTOCOL = <% if $server2['protocol'].empty { -%>TCP<% } else { -%><%= $server2['protocol'] %> <%} -%>)(HOST = <%= $server2['host'] %>)(PORT = <%= $server2['port'] %>))
     <%- } -%>
   <%- } -%>
   <%- unless $size == 1 { -%>
@@ -18,7 +18,7 @@
      (LOAD_BALANCE = <%= $loadbalance %>)
      (FAILOVER = <%= $failover %>)
      <%- $server.each |$key, $server2| { -%>
-     (ADDRESS = (PROTOCOL = <%= $server2['protocol'] %>)(HOST = <%= $server2['host'] %>)(PORT = <%= $server2['port'] %>))
+     (ADDRESS = (PROTOCOL = <% if $server2['protocol'].empty { -%>TCP<% } else { -%>%<= $server2['protocol'] %> <%} -%>)(HOST = <%= $server2['host'] %>)(PORT = <%= $server2['port'] %>))
      <%- } -%>
     )
   <%- } -%>


### PR DESCRIPTION
This helps to save some coding if the PROTOCOL is defaulted to TCP.