### PR TITLE
Add tnsnames.ora parameters

### DIFF
--- a/manifests/tnsnames.pp
+++ b/manifests/tnsnames.pp
@@ -30,18 +30,24 @@
 # @param failover configure failover on the tnsnames entries
 # @param connect_service_name the service name of the database
 # @param connect_server service connection type
+# @param connect_timeout the timeout duration in seconds for a client to establish an Oracle Net connection to an Oracle database
+# @param transport_connect_timeout the transportation timeout duration in seconds for a client to establish an Oracle Net connection to an Oracle Database
+# @param retry_count The number of times an ADDRESS list is traversed before the connection attempt is terminated. The default value is 0.
 # @param entry_type type of configuration
 #
 define oradb::tnsnames(
-  String $oracle_home                     = undef,
-  String $user                            = lookup('oradb::user'),
-  String $group                           = lookup('oradb::group'),
-  Hash   $server                          = { myserver => { host => undef, port => '1521', protocol => 'TCP' }},
-  String $loadbalance                     = 'ON',
-  String $failover                        = 'ON',
-  Optional[String] $connect_service_name  = undef,
-  String $connect_server                  = 'DEDICATED',
-  Enum['tnsnames','listener'] $entry_type = 'tnsnames',
+  String $oracle_home                          = undef,
+  String $user                                 = lookup('oradb::user'),
+  String $group                                = lookup('oradb::group'),
+  Hash   $server                               = { myserver => { host => undef, port => '1521', protocol => 'TCP' }},
+  String $loadbalance                          = 'ON',
+  String $failover                             = 'ON',
+  Optional[String] $connect_service_name       = undef,
+  String $connect_server                       = 'DEDICATED',
+  Optional[Integer] $connect_timeout           = undef,
+  Optional[Integer] $transport_connect_timeout = undef,
+  Optional[Integer] $retry_count               = undef,
+  Enum['tnsnames','listener'] $entry_type      = 'tnsnames',
 )
 {
   if ! defined(Concat["${oracle_home}/network/admin/tnsnames.ora"]) {
@@ -60,19 +66,17 @@ define oradb::tnsnames(
     default    : { fail("${entry_type} is not a supported entry_type") }
   }
 
-  $size = keys($server).size
-
-  # puppet epp render tnsnames.epp --values "{size => 1 ,title => 'a', server => { myserver => { host => 'dbcdb.example.com',  port => '1525', protocol => 'TCP' }} , loadbalance => 'ON', failover => 'ON' , connect_server => 'aa' , connect_service_name => 'aaa' }"
-  # puppet epp render tnsnames.epp --values "{size => 2 , title => 'a', server => { myserver => { host => 'dbcdb.example.com', port => '1525', protocol => 'TCP' }, myserver2 =>  { host => 'dbcdb.example.com', port => '1526', protocol => 'TCP' }  } , loadbalance => 'ON', failover => 'ON' , connect_server => 'aa' , connect_service_name => 'aaa' }"
   concat::fragment { $title:
     target  => "${oracle_home}/network/admin/tnsnames.ora",
-    content => epp($template_path , { 'title'                => $title,
-                                      'server'               => $server,
-                                      'loadbalance'          => $loadbalance,
-                                      'failover'             => $failover,
-                                      'connect_server'       => $connect_server,
-                                      'connect_service_name' => $connect_service_name,
-                                      'size'                 => $size
+    content => epp($template_path , { 'title'                     => $title,
+                                      'server'                    => $server,
+                                      'loadbalance'               => $loadbalance,
+                                      'failover'                  => $failover,
+                                      'connect_server'            => $connect_server,
+                                      'connect_service_name'      => $connect_service_name,
+                                      'connect_timeout'           => $connect_timeout,
+                                      'transport_connect_timeout' => $transport_connect_timeout,
+                                      'retry_count'               => $retry_count,
                                       }),
   }
 }

--- a/templates/tnsnames.epp
+++ b/templates/tnsnames.epp
@@ -3,28 +3,34 @@
        String $loadbalance,
        String $failover,
        String $connect_server,
-       String $connect_service_name,
-       Integer $size | -%>
+       Optional[Integer] $connect_timeout           = undef,
+       Optional[Integer] $transport_connect_timeout = undef,
+       Optional[Integer] $retry_count               = undef,
+       String $connect_service_name | -%> 
 
 <%= $title %> =
   (DESCRIPTION =
-  <%- if $size == 1 { -%>
-    <%- $server.each |$key, $server2| { -%>
-    (ADDRESS = (PROTOCOL = <% if $server2['protocol'].empty { -%>TCP<% } else { -%><%= $server2['protocol'] %> <%} -%>)(HOST = <%= $server2['host'] %>)(PORT = <%= $server2['port'] %>))
-    <%- } -%>
-  <%- } -%>
-  <%- unless $size == 1 { -%>
+  <%- unless $connect_timeout.empty { -%>
+    (CONNECT_TIMEOUT = <%= $connect_timeout %>)
+  <%- } -%> 
+  <%- unless $transport_connect_timeout.empty { -%>
+    (TRANSPORT_CONNECT_TIMEOUT = <%= $transport_connect_timeout %>)
+  <%- } -%> 
+  <%- unless $retry_count.empty { -%>
+    (RETRY_COUNT = <%= $retry_count %>)
+  <%- } -%> 
+  <%- if $server.size() > 1 { -%> 
     (ADDRESS_LIST=
-     (LOAD_BALANCE = <%= $loadbalance %>)
-     (FAILOVER = <%= $failover %>)
-     <%- $server.each |$key, $server2| { -%>
-     (ADDRESS = (PROTOCOL = <% if $server2['protocol'].empty { -%>TCP<% } else { -%>%<= $server2['protocol'] %> <%} -%>)(HOST = <%= $server2['host'] %>)(PORT = <%= $server2['port'] %>))
-     <%- } -%>
-    )
-  <%- } -%>
+      (LOAD_BALANCE = <%= $loadbalance %>) 
+      (FAILOVER = <%= $failover %>) 
+  <%- } -%> 
+    <%- $server.each |$key, $server2| { -%> 
+    (ADDRESS = (PROTOCOL = <%= getvar('server2.protocol','TCP').upcase() -%> )(HOST = <%= $server2['host'] %>)(PORT = <%= $server2['port'] %>))
+    <%- } -%> 
     (CONNECT_DATA =
-      (SERVER = <%= $connect_server %>)
-      (SERVICE_NAME = <%= $connect_service_name %>)
-    )
+      <%- unless $connect_server.empty { -%>
+      (SERVER = <%= $connect_server %>) 
+      <%- } -%> 
+      (SERVICE_NAME = <%= $connect_service_name %>) 
+    )   
   )
-


### PR DESCRIPTION
I've added the following parameters to the tnsnames.ora file:

CONNECT_TIMEOUT
TRANSPORT_CONNECT_TIMEOUT
RETRY_COUNT

In addition, I've simplified the default PROTOCOL logic and consolidated the load balanced logic into a single loop.