### PR TITLE
replace legacy facts

### DIFF
--- a/manifests/installem_agent.pp
+++ b/manifests/installem_agent.pp
@@ -90,7 +90,7 @@ define oradb::installem_agent(
   String $download_dir                               = lookup('oradb::download_dir'),
   Boolean $log_output                                = false,
   Boolean $ignore_sys_prerequisite                   = false,
-  String $oracle_hostname                            = lookup('oradb::oracle_hostname',{default_value => $::fqdn}),
+  String $oracle_hostname                            = lookup('oradb::oracle_hostname',{default_value => $facts['networking']['fqdn']}),
   Boolean $manage_curl                               = true,
 )
 {

--- a/manifests/prepareautostart.pp
+++ b/manifests/prepareautostart.pp
@@ -33,7 +33,7 @@ class oradb::prepareautostart(
                         '\r\n', "\n", 'EMG'),
   }
 
-  case $facts['operatingsystem'] {
+  case $facts['os']['name'] {
     'CentOS', 'RedHat', 'OracleLinux', 'SLES': {
       exec { "enable service ${service_name}":
         command   => "chkconfig --add ${service_name}",

--- a/spec/classes/prepareautostart_spec.rb
+++ b/spec/classes/prepareautostart_spec.rb
@@ -9,7 +9,7 @@ describe 'oradb::prepareautostart', :type => :class do
   # rspec-puppet does not allow you to swap out hiera data on a per test block
   #include_context :hiera
 
-  
+
   # below is the facts hash that gives you the ability to mock
   # facts on a per describe/context block.  If you use a fact in your
   # manifest you should mock the facts below.
@@ -32,7 +32,7 @@ describe 'oradb::prepareautostart', :type => :class do
   describe 'Solaris' do
     let(:facts) {{
         :kernel => 'SunOS',
-        :operatingsystem => 'Solaris'
+        :os => {name: 'Solaris'}
     }}
 
     it do
@@ -68,7 +68,7 @@ describe 'oradb::prepareautostart', :type => :class do
 
   describe 'Linux' do
     let(:facts) do
-      {:kernel => 'Linux', :operatingsystem => 'RedHat'}
+      {:kernel => 'Linux', :os => {name: 'RedHat'}}
     end
 
     it do
@@ -88,7 +88,7 @@ describe 'oradb::prepareautostart', :type => :class do
           {
 
             :kernel => 'Linux',
-            :operatingsystem => os
+            :os => {name: os}
           }
 
         end
@@ -111,7 +111,7 @@ describe 'oradb::prepareautostart', :type => :class do
         let(:facts) do
           {
             :kernel => 'Linux',
-            :operatingsystem => os
+            :os => {name: os}
           }
 
         end

--- a/spec/defines/database_params_spec.rb
+++ b/spec/defines/database_params_spec.rb
@@ -14,9 +14,8 @@ describe 'oradb::database', :type => :define do
                    :db_domain               => 'xxxxx',
     }}
     let(:title) {'testDb_Create'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_file("/install/database_testDb_Create.rsp")
@@ -38,9 +37,8 @@ describe 'oradb::database', :type => :define do
                    :db_domain               => 'xxxxx',
     }}
     let(:title) {'testDb_Create'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_file("/install/database_testDb_Create.rsp")
@@ -61,9 +59,8 @@ describe 'oradb::database', :type => :define do
                    :database_type            => "XXXX",
     }}
     let(:title) {'testDb_Create'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_file("/install/database_testDb_Create.rsp")
@@ -84,9 +81,8 @@ describe 'oradb::database', :type => :define do
                    :em_configuration         => "XXXX",
     }}
     let(:title) {'testDb_Create'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_file("/install/database_testDb_Create.rsp")
@@ -107,9 +103,8 @@ describe 'oradb::database', :type => :define do
                    :storage_type             => "XXXX",
     }}
     let(:title) {'testDb_Create'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_file("/install/database_testDb_Create.rsp")
@@ -131,9 +126,8 @@ describe 'oradb::database', :type => :define do
                    :db_domain               => 'a'
     }}
     let(:title) {'testDb_Create'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_file("/install/database_testDb_Create.rsp")
@@ -146,9 +140,8 @@ describe 'oradb::database', :type => :define do
   describe "init params" do
 
     let(:title) {'testDb_Create'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
     let(:base_params) {{
                          :oracle_base              => '/oracle',
                          :oracle_home              => '/oracle/product/11.2/db',

--- a/spec/defines/database_pluggable_spec.rb
+++ b/spec/defines/database_pluggable_spec.rb
@@ -16,9 +16,8 @@ describe 'oradb::database_pluggable', :type => :define do
          :pdb_admin_password       => 'Welcome01'
     }}
     let(:title) {'pdb1'}
-    let(:facts) {{ :operatingsystem => 'CentOS',
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_exec("dbca pdb execute pdb1")
@@ -41,9 +40,8 @@ describe 'oradb::database_pluggable', :type => :define do
          :pdb_admin_password       => 'Welcome01'
     }}
     let(:title) {'pdb1'}
-    let(:facts) {{ :operatingsystem => 'CentOS',
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_exec("dbca pdb execute pdb1")
@@ -65,9 +63,8 @@ describe 'oradb::database_pluggable', :type => :define do
          :pdb_admin_password       => 'Welcome01'
     }}
     let(:title) {'pdb1'}
-    let(:facts) {{ :operatingsystem => 'CentOS',
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_exec("dbca pdb execute pdb1")
@@ -89,9 +86,8 @@ describe 'oradb::database_pluggable', :type => :define do
          :pdb_admin_username       => 'pdb_adm',
     }}
     let(:title) {'pdb1'}
-    let(:facts) {{ :operatingsystem => 'CentOS',
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_exec("dbca pdb execute pdb1")
@@ -113,9 +109,8 @@ describe 'oradb::database_pluggable', :type => :define do
          :pdb_admin_password       => 'Welcome01'
     }}
     let(:title) {'pdb1'}
-    let(:facts) {{ :operatingsystem => 'CentOS',
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_exec("dbca pdb execute pdb1")
@@ -137,9 +132,8 @@ describe 'oradb::database_pluggable', :type => :define do
          :pdb_admin_password       => 'Welcome01'
     }}
     let(:title) {'pdb1'}
-    let(:facts) {{ :operatingsystem => 'CentOS',
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_exec("dbca pdb execute pdb1")
@@ -161,9 +155,8 @@ describe 'oradb::database_pluggable', :type => :define do
          :pdb_admin_password       => 'Welcome01'
     }}
     let(:title) {'pdb1'}
-    let(:facts) {{ :operatingsystem => 'CentOS',
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_exec("dbca pdb execute pdb1")

--- a/spec/defines/installasm_params_spec.rb
+++ b/spec/defines/installasm_params_spec.rb
@@ -54,9 +54,8 @@ describe 'oradb::installasm', :type => :define do
           :asm_monitor_password    => 'Welcome01',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installasm /app/grid/product/11.2/grid does not exists")
@@ -85,9 +84,8 @@ describe 'oradb::installasm', :type => :define do
           :disk_au_size            => 200,
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installasm /app/grid/product/11.2/grid does not exists")

--- a/spec/defines/installdb_params_spec.rb
+++ b/spec/defines/installdb_params_spec.rb
@@ -19,9 +19,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point  => '/software',
                 }}
     let(:title) {'10.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installdb /oracle/product/10.2/db does not exists")
@@ -48,9 +47,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point  => '/software',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installdb /oracle/product/11.2/db does not exists")
@@ -75,9 +73,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point  => '/software',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installdb /oracle/product/11.2/db does not exists")
@@ -103,9 +100,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point  => '/software',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installdb /oracle/product/11.2/db does not exists")
@@ -130,9 +126,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point  => '/software',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installdb /oracle/product/11.2/db does not exists")
@@ -157,9 +152,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point  => '/software',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installdb /oracle/product/11.2/db does not exists")
@@ -185,9 +179,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point  => '/software',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     it do
       expect { should contain_notify("oradb::installdb /oracle/product/11.2/db does not exists")

--- a/spec/defines/installdb_remote_spec.rb
+++ b/spec/defines/installdb_remote_spec.rb
@@ -20,9 +20,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point => '/software' }
     let(:params) { default_params }
     let(:title) {'12.1.0.1_Linux-x86-64'}
-    default_facts = { :operatingsystem => 'CentOS',
-                      :kernel          => 'Linux',
-                      :osfamily        => 'RedHat' }
+    default_facts = { :os              => {name: 'CentOS', family: 'RedHat'},
+                      :kernel          => 'Linux' }
     let(:facts) { default_facts }
     context 'with no oradb_inst_loc_data fact' do
       describe "oradb utils structure" do
@@ -178,9 +177,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point => '/software',
                 }}
     let(:title) {'11.2.0.4_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'CentOS' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'CentOS', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
     describe "oradb utils structure" do
       it do
@@ -283,9 +281,8 @@ describe 'oradb::installdb', :type => :define do
           :puppet_download_mnt_point => '/software',
                 }}
     let(:title) {'11.2.0.3_Linux-x86-64'}
-    let(:facts) {{ :operatingsystem => 'OracleLinux' ,
-                   :kernel          => 'Linux',
-                   :osfamily        => 'RedHat' }}
+    let(:facts) {{ :os              => {name: 'OracleLinux', family: 'RedHat'} ,
+                   :kernel          => 'Linux'}}
 
 
     describe "oradb utils structure" do


### PR DESCRIPTION
Puppet 8 agents default to not sending legacy facts