### PR TITLE
Fix closing parenthesis in tnsnames ora

### DIFF
--- a/templates/tnsnames.epp
+++ b/templates/tnsnames.epp
@@ -27,6 +27,9 @@
     <%- $server.each |$key, $server2| { -%> 
     (ADDRESS = (PROTOCOL = <%= getvar('server2.protocol','TCP').upcase() -%> )(HOST = <%= $server2['host'] %>)(PORT = <%= $server2['port'] %>))
     <%- } -%> 
+  <%- if $server.size() > 1 { -%> 
+    )
+  <%- } -%> 
     (CONNECT_DATA =
       <%- unless $connect_server.empty { -%>
       (SERVER = <%= $connect_server %>) 


### PR DESCRIPTION
Closes #310

Fix lack of closing parenthesis in ADDRESS_LIST section when multiple servers.